### PR TITLE
Fix bug in the handling of MDC when extracting signature information

### DIFF
--- a/debian/postgresql-pgcrypto-openpgp/patches/9/110-pgp-armor-headers.patch
+++ b/debian/postgresql-pgcrypto-openpgp/patches/9/110-pgp-armor-headers.patch
@@ -1,138 +1,129 @@
 diff --git a/expected/pgp-armor.out b/expected/pgp-armor.out
-index c955494..9d740c7 100644
+index c955494..d5d8a59 100644
 --- a/expected/pgp-armor.out
 +++ b/expected/pgp-armor.out
-@@ -102,3 +102,261 @@ em9va2E=
+@@ -102,3 +102,319 @@ em9va2E=
  -----END PGP MESSAGE-----
  ');
  ERROR:  Corrupt ascii-armor
-+-- corrupt
-+select pgp_armor_header('
++-- corrupt (no space after the colon)
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +foo:
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'foo');
++');
 +ERROR:  Corrupt ascii-armor
-+-- empty
-+select pgp_armor_header('
++-- corrupt (no empty line)
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++ERROR:  Corrupt ascii-armor
++-- no headers
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++ key | value 
++-----+-------
++(0 rows)
++
++-- header with empty value
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +foo: 
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'foo');
-+ pgp_armor_header 
-+------------------
-+ 
++');
++ key | value 
++-----+-------
++ foo | 
 +(1 row)
 +
 +-- simple
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
-+foo: bar
++fookey: foovalue
++barkey: barvalue
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'foo');
-+ pgp_armor_header 
-+------------------
-+ bar
-+(1 row)
-+
-+-- uninteresting keys, part 1
-+select pgp_armor_header('
-+-----BEGIN PGP MESSAGE-----
-+foo: found
-+bar: ignored
-+
-+em9va2E=
-+=ZZZZ
-+-----END PGP MESSAGE-----
-+', 'foo');
-+ pgp_armor_header 
-+------------------
-+ found
-+(1 row)
-+
-+-- uninteresting keys, part 2
-+select pgp_armor_header('
-+-----BEGIN PGP MESSAGE-----
-+bar: ignored
-+foo: found
-+
-+em9va2E=
-+=ZZZZ
-+-----END PGP MESSAGE-----
-+', 'foo');
-+ pgp_armor_header 
-+------------------
-+ found
-+(1 row)
-+
-+-- uninteresting keys, part 3
-+select pgp_armor_header('
-+-----BEGIN PGP MESSAGE-----
-+bar: ignored
-+foo: found
-+bar: ignored
-+
-+em9va2E=
-+=ZZZZ
-+-----END PGP MESSAGE-----
-+', 'foo');
-+ pgp_armor_header 
-+------------------
-+ found
-+(1 row)
++');
++  key   |  value   
++--------+----------
++ fookey | foovalue
++ barkey | barvalue
++(2 rows)
 +
 +-- insane keys, part 1
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +insane:key : 
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'insane:key ');
-+ pgp_armor_header 
-+------------------
-+ 
++');
++     key     | value 
++-------------+-------
++ insane:key  | 
 +(1 row)
 +
 +-- insane keys, part 2
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +insane:key : text value here
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'insane:key ');
-+ pgp_armor_header 
-+------------------
-+ text value here
++');
++     key     |      value      
++-------------+-----------------
++ insane:key  | text value here
 +(1 row)
 +
 +-- long value
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +long: this value is more than 76 characters long, but it should still parse correctly as that''s permitted by RFC 4880
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'long');
-+                                                pgp_armor_header                                                 
-+-----------------------------------------------------------------------------------------------------------------
-+ this value is more than 76 characters long, but it should still parse correctly as that's permitted by RFC 4880
++');
++ key  |                                                      value                                                      
++------+-----------------------------------------------------------------------------------------------------------------
++ long | this value is more than 76 characters long, but it should still parse correctly as that's permitted by RFC 4880
 +(1 row)
 +
 +-- long value, split up
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++long: this value is more than 76 characters long, but it should still 
++long: parse correctly as that''s permitted by RFC 4880
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++ key  |                              value                               
++------+------------------------------------------------------------------
++ long | this value is more than 76 characters long, but it should still 
++ long | parse correctly as that's permitted by RFC 4880
++(2 rows)
++
 +select pgp_armor_header('
 +-----BEGIN PGP MESSAGE-----
 +long: this value is more than 76 characters long, but it should still 
@@ -148,7 +139,24 @@ index c955494..9d740c7 100644
 +(1 row)
 +
 +-- long value, split up, part 2
-+select pgp_armor_header('
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++long: this value is more than 
++long: 76 characters long, but it should still 
++long: parse correctly as that''s permitted by RFC 4880
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++ key  |                      value                      
++------+-------------------------------------------------
++ long | this value is more than 
++ long | 76 characters long, but it should still 
++ long | parse correctly as that's permitted by RFC 4880
++(3 rows)
++
++select * from pgp_armor_header('
 +-----BEGIN PGP MESSAGE-----
 +long: this value is more than 
 +long: 76 characters long, but it should still 
@@ -164,15 +172,40 @@ index c955494..9d740c7 100644
 +(1 row)
 +
 +-- long value, split up, part 3
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
-+ignored: 
++emptykey: 
 +long: this value is more than 
-+ignored: 
++emptykey: 
 +long: 76 characters long, but it should still 
-+ignored: 
++emptykey: 
 +long: parse correctly as that''s permitted by RFC 4880
-+ignored: 
++emptykey: 
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++   key    |                      value                      
++----------+-------------------------------------------------
++ emptykey | 
++ long     | this value is more than 
++ emptykey | 
++ long     | 76 characters long, but it should still 
++ emptykey | 
++ long     | parse correctly as that's permitted by RFC 4880
++ emptykey | 
++(7 rows)
++
++select * from pgp_armor_header('
++-----BEGIN PGP MESSAGE-----
++emptykey: 
++long: this value is more than 
++emptykey: 
++long: 76 characters long, but it should still 
++emptykey: 
++long: parse correctly as that''s permitted by RFC 4880
++emptykey: 
 +
 +em9va2E=
 +=ZZZZ
@@ -183,7 +216,7 @@ index c955494..9d740c7 100644
 + this value is more than 76 characters long, but it should still parse correctly as that's permitted by RFC 4880
 +(1 row)
 +
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +Comment: dat1.blowfish.sha1.mdc.s2k3.z0
 +
@@ -191,11 +224,27 @@ index c955494..9d740c7 100644
 +yA6Ce1QTMK3KdL2MPfamsTUSAML8huCJMwYQFfE=
 +=JcP+
 +-----END PGP MESSAGE-----
-+', 'Comment');
-+        pgp_armor_header        
-+--------------------------------
-+ dat1.blowfish.sha1.mdc.s2k3.z0
++');
++   key   |             value              
++---------+--------------------------------
++ Comment | dat1.blowfish.sha1.mdc.s2k3.z0
 +(1 row)
++
++-- test CR+LF line endings
++select * from pgp_armor_headers(replace('
++-----BEGIN PGP MESSAGE-----
++fookey: foovalue
++barkey: barvalue
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++', E'\n', E'\r\n'));
++  key   |  value   
++--------+----------
++ fookey | foovalue
++ barkey | barvalue
++(2 rows)
 +
 +-- test header generation
 +select armor('zooka', array['foo'], array['bar']);
@@ -210,24 +259,27 @@ index c955494..9d740c7 100644
 + 
 +(1 row)
 +
-+select armor('zooka', array['Version', 'Comment'], array['Created by pgcrypto', 'PostgreSQL, the world''s most most advanced open source database']);
-+                                  armor                                   
-+--------------------------------------------------------------------------
-+ -----BEGIN PGP MESSAGE-----                                             +
-+ Version: Created by pgcrypto                                            +
-+ Comment: PostgreSQL, the world's most most advanced open source database+
-+                                                                         +
-+ em9va2E=                                                                +
-+ =D5cR                                                                   +
-+ -----END PGP MESSAGE-----                                               +
++select armor('zooka', array['Version', 'Comment'], array['Created by pgcrypto', 'PostgreSQL, the world''s most advanced open source database']);
++                                armor                                
++---------------------------------------------------------------------
++ -----BEGIN PGP MESSAGE-----                                        +
++ Version: Created by pgcrypto                                       +
++ Comment: PostgreSQL, the world's most advanced open source database+
++                                                                    +
++ em9va2E=                                                           +
++ =D5cR                                                              +
++ -----END PGP MESSAGE-----                                          +
 + 
 +(1 row)
 +
-+select pgp_armor_header(armor('zooka', array['Version', 'Comment'], array['Created by pgcrypto', 'PostgreSQL, the world''s most most advanced open source database']), 'Comment');
-+                        pgp_armor_header                         
-+-----------------------------------------------------------------
-+ PostgreSQL, the world's most most advanced open source database
-+(1 row)
++select * from pgp_armor_headers(
++  armor('zooka', array['Version', 'Comment'],
++                 array['Created by pgcrypto', 'PostgreSQL, the world''s most advanced open source database']));
++   key   |                           value                            
++---------+------------------------------------------------------------
++ Version | Created by pgcrypto
++ Comment | PostgreSQL, the world's most advanced open source database
++(2 rows)
 +
 +-- error/corner cases
 +select armor('', array['foo'], array['too', 'many']);
@@ -264,11 +316,17 @@ index c955494..9d740c7 100644
 + 
 +(1 row)
 +
++select armor('', array[E'embedded\nnewline'], array['foo']);
++ERROR:  header key must not contain newlines
++select armor('', array['foo'], array[E'embedded\nnewline']);
++ERROR:  header value must not contain newlines
++select armor('', array['embedded: colon+space'], array['foo']);
++ERROR:  header key must not contain ": "
 diff --git a/pgcrypto_openpgp--1.2.sql b/pgcrypto_openpgp--1.2.sql
-index 8d794d3..4debd7e 100644
+index 8d794d3..8b5e918 100644
 --- a/pgcrypto_openpgp--1.2.sql
 +++ b/pgcrypto_openpgp--1.2.sql
-@@ -200,3 +200,18 @@ CREATE FUNCTION dearmor(text)
+@@ -200,3 +200,25 @@ CREATE FUNCTION dearmor(text)
  RETURNS bytea
  AS 'MODULE_PATHNAME', 'pg_dearmor'
  LANGUAGE C IMMUTABLE STRICT;
@@ -282,16 +340,31 @@ index 8d794d3..4debd7e 100644
 +AS 'MODULE_PATHNAME', 'pg_armor'
 +LANGUAGE C IMMUTABLE STRICT;
 +
-+CREATE FUNCTION pgp_armor_header(text, text)
-+RETURNS text
-+AS 'MODULE_PATHNAME', 'pgp_armor_header_w'
++CREATE FUNCTION pgp_armor_headers(text, key OUT text, value OUT text)
++RETURNS SETOF record
++AS 'MODULE_PATHNAME', 'pgp_armor_headers'
 +LANGUAGE C IMMUTABLE STRICT;
 +
++CREATE FUNCTION pgp_armor_header(text, text)
++RETURNS text
++AS $$
++SELECT string_agg(h.value, '') FROM pgp_armor_headers($1) h WHERE h.key = $2
++$$
++LANGUAGE sql IMMUTABLE STRICT;
++
 diff --git a/pgp-armor.c b/pgp-armor.c
-index 87adf91..86a0810 100644
+index 87adf91..3a7f51d 100644
 --- a/pgp-armor.c
 +++ b/pgp-armor.c
-@@ -179,7 +179,7 @@ b64_dec_len(unsigned srclen)
+@@ -32,7 +32,6 @@
+ #include "postgres.h"
+ 
+ #include "px.h"
+-#include "mbuf.h"
+ #include "pgp.h"
+ 
+ /*
+@@ -179,7 +178,7 @@ b64_dec_len(unsigned srclen)
   * PGP armor
   */
  
@@ -300,193 +373,291 @@ index 87adf91..86a0810 100644
  static const char *armor_footer = "\n-----END PGP MESSAGE-----\n";
  
  /* CRC24 implementation from rfc2440 */
-@@ -205,7 +205,8 @@ crc24(const uint8 *data, unsigned len)
+@@ -204,38 +203,40 @@ crc24(const uint8 *data, unsigned len)
+ 	return crc & 0xffffffL;
  }
  
- int
+-int
 -pgp_armor_encode(const uint8 *src, unsigned len, uint8 *dst)
-+pgp_armor_encode(const uint8 *src, unsigned len, uint8 *dst,
++void
++pgp_armor_encode(const uint8 *src, unsigned len, StringInfo dst,
 +				 int num_headers, char **keys, char **values)
  {
  	int			n;
- 	uint8	   *pos = dst;
-@@ -215,6 +216,22 @@ pgp_armor_encode(const uint8 *src, unsigned len, uint8 *dst)
- 	memcpy(pos, armor_header, n);
- 	pos += n;
+-	uint8	   *pos = dst;
++	int			res;
++	unsigned	b64len;
+ 	unsigned	crc = crc24(src, len);
  
+-	n = strlen(armor_header);
+-	memcpy(pos, armor_header, n);
+-	pos += n;
++	appendStringInfoString(dst, armor_header);
++
 +	for (n = 0; n < num_headers; n++)
-+	{
-+		size_t keylen = strlen(keys[n]);
-+		size_t valuelen = strlen(values[n]);
-+
-+		memcpy(pos, keys[n], keylen);
-+		pos += keylen;
-+		*pos++ = ':';
-+		*pos++ = ' ';
-+		memcpy(pos, values[n], valuelen);
-+		pos += valuelen;
-+		*pos++ = '\n';
-+	}
-+
-+	*pos++ = '\n';
-+
- 	n = b64_encode(src, len, pos);
- 	pos += n;
++		appendStringInfo(dst, "%s: %s\n", keys[n], values[n]);
++	appendStringInfoChar(dst, '\n');
  
-@@ -370,10 +387,116 @@ out:
+-	n = b64_encode(src, len, pos);
+-	pos += n;
++	/* make sure we have enough room to b64_encode() */
++	b64len = b64_enc_len(len);
++	enlargeStringInfo(dst, (int) b64len);
+ 
+-	if (*(pos - 1) != '\n')
+-		*pos++ = '\n';
++	res = b64_encode(src, len, (uint8 *) dst->data + dst->len);
++	if (res > b64len)
++		elog(FATAL, "overflow - encode estimate too small");
++	dst->len += res;
+ 
+-	*pos++ = '=';
+-	pos[3] = _base64[crc & 0x3f];
+-	crc >>= 6;
+-	pos[2] = _base64[crc & 0x3f];
+-	crc >>= 6;
+-	pos[1] = _base64[crc & 0x3f];
+-	crc >>= 6;
+-	pos[0] = _base64[crc & 0x3f];
+-	pos += 4;
++	if (*(dst->data + dst->len - 1) != '\n')
++		appendStringInfoChar(dst, '\n');
+ 
+-	n = strlen(armor_footer);
+-	memcpy(pos, armor_footer, n);
+-	pos += n;
++	appendStringInfoChar(dst, '=');
++	appendStringInfoChar(dst, _base64[(crc >> 18) & 0x3f]);
++	appendStringInfoChar(dst, _base64[(crc >> 12) & 0x3f]);
++	appendStringInfoChar(dst, _base64[(crc >> 6) & 0x3f]);
++	appendStringInfoChar(dst, _base64[crc & 0x3f]);
+ 
+-	return pos - dst;
++	appendStringInfoString(dst, armor_footer);
+ }
+ 
+ static const uint8 *
+@@ -310,7 +311,7 @@ find_header(const uint8 *data, const uint8 *datend,
+ }
+ 
+ int
+-pgp_armor_decode(const uint8 *src, unsigned len, uint8 *dst)
++pgp_armor_decode(const uint8 *src, int len, StringInfo dst)
+ {
+ 	const uint8 *p = src;
+ 	const uint8 *data_end = src + len;
+@@ -320,6 +321,7 @@ pgp_armor_decode(const uint8 *src, unsigned len, uint8 *dst)
+ 	const uint8 *base64_end = NULL;
+ 	uint8		buf[4];
+ 	int			hlen;
++	int			blen;
+ 	int			res = PXE_PGP_CORRUPT_ARMOR;
+ 
+ 	/* armor start */
+@@ -361,23 +363,126 @@ pgp_armor_decode(const uint8 *src, unsigned len, uint8 *dst)
+ 	crc = (((long) buf[0]) << 16) + (((long) buf[1]) << 8) + (long) buf[2];
+ 
+ 	/* decode data */
+-	res = b64_decode(base64_start, base64_end - base64_start, dst);
+-
+-	/* check crc */
+-	if (res >= 0 && crc24(dst, res) != crc)
+-		res = PXE_PGP_CORRUPT_ARMOR;
++	blen = (int) b64_dec_len(len);
++	enlargeStringInfo(dst, blen);
++	res = b64_decode(base64_start, base64_end - base64_start, (uint8 *) dst->data);
++	if (res > blen)
++		elog(FATAL, "overflow - decode estimate too small");
++	if (res >= 0)
++	{
++		if (crc24((uint8 *) dst->data, res) == crc)
++			dst->len += res;
++		else
++			res = PXE_PGP_CORRUPT_ARMOR;
++	}
+ out:
  	return res;
  }
  
-+int
-+pgp_armor_header(const uint8 *src, unsigned len, const char *key,
-+				 unsigned key_len, uint8 **dst, int *out_len)
-+{
-+	const uint8 *p = src;
-+	const uint8 *data_end = src + len;
-+	const uint8 *armor_end;
-+	const uint8 *eol,
-+				*colon;
-+	MBuf	   *buf = NULL;
-+	int			hlen;
-+	int			res = PXE_PGP_CORRUPT_ARMOR;
-+
-+	/* armor start */
-+	hlen = find_header(src, data_end, &p, 0);
-+	if (hlen <= 0)
-+		goto out;
-+	p += hlen;
-+
-+	/* armor end */
-+	hlen = find_header(p, data_end, &armor_end, 1);
-+	if (hlen <= 0)
-+		goto out;
-+
-+	/* read comments until an empty line or the end of data */
-+	while (p < armor_end)
-+	{
-+		res = PXE_PGP_CORRUPT_ARMOR;
-+
-+		if (*p == '\n' || *p == '\r')
-+		{
-+			res = 0;
-+			break;
-+		}
-+
-+		eol = memchr(p, '\n', armor_end - p);
-+		if (!eol)
-+			goto out;
-+
-+		/* find the next key */
-+		colon = p;
-+		while (1)
-+		{
-+			colon = memchr(colon, ':', eol - colon);
-+			if (!colon)
-+				goto out;
-+			if (colon == eol)
-+				goto out;
-+
-+			/* if it's not followed by a space, this isn't the full key */
-+			if (*(colon + 1) == ' ')
-+				break;
-+			colon = colon + 1;
-+		}
-+
-+		if (key_len == colon - p &&
-+			memcmp(p, key, key_len) == 0)
-+		{
-+			size_t valuelen;
-+			valuelen = eol - colon - 2;
-+			if (!buf)
-+				buf = mbuf_create(valuelen + 1);
-+
-+			res = mbuf_append(buf, colon + 2, (int) valuelen);
-+			if (res < 0)
-+				goto out;
-+		}
-+		/* step to start of next line */
-+		p = eol + 1;
-+	}
-+
-+out:
-+	if (res < 0)
-+	{
-+		if (buf)
-+			px_free(buf);
-+		*dst = NULL;
-+		*out_len = -1;
-+		return res;
-+	}
-+	else
-+	{
-+		if (buf)
-+		{
-+			/* 0-terminate the string for the caller */
-+			res = mbuf_append(buf, (uint8 *) "\x00", 1);
-+			if (res < 0)
-+				return res;
-+			*out_len = mbuf_steal_data(buf, dst) - 1;
-+		}
-+		else
-+		{
-+			*dst = NULL;
-+			*out_len = 0;
-+		}
-+		return 0;
-+	}
-+}
-+
- unsigned
+-unsigned
 -pgp_armor_enc_len(unsigned len)
-+pgp_armor_enc_len(unsigned len, int num_headers, char **keys, char **values)
++/*
++ * Extracts all armor headers from an ASCII-armored input.
++ *
++ * Returns 0 on success, or PXE_* error code on error. On success, the
++ * number of headers and their keys and values are returned in *nheaders,
++ * *nkeys and *nvalues.
++ */
++int
++pgp_extract_armor_headers(const uint8 *src, unsigned len,
++						  int *nheaders, char ***keys, char ***values)
  {
 -	return b64_enc_len(len) + strlen(armor_header) + strlen(armor_footer) + 16;
-+	int i;
-+	unsigned header_length = 0;
-+
-+	for (i = 0; i < num_headers; i++)
-+		header_length += strlen(keys[i]) + strlen(values[i]) + 2 + 1;
-+
-+	return strlen(armor_header) + header_length + 1 +
-+		   b64_enc_len(len) + strlen(armor_footer) + 16;
- }
+-}
++	const uint8 *data_end = src + len;
++	const uint8 *p;
++	const uint8 *base64_start;
++	const uint8 *armor_start;
++	const uint8 *armor_end;
++	Size		armor_len;
++	char	   *line;
++	char	   *nextline;
++	char	   *eol,
++				*colon;
++	int			hlen;
++	char	   *buf;
++	int			hdrlines;
++	int			n;
  
- unsigned
+-unsigned
+-pgp_armor_dec_len(unsigned len)
+-{
+-	return b64_dec_len(len);
++	/* armor start */
++	hlen = find_header(src, data_end, &armor_start, 0);
++	if (hlen <= 0)
++		return PXE_PGP_CORRUPT_ARMOR;
++	armor_start += hlen;
++
++	/* armor end */
++	hlen = find_header(armor_start, data_end, &armor_end, 1);
++	if (hlen <= 0)
++		return PXE_PGP_CORRUPT_ARMOR;
++
++	/* Count the number of armor header lines. */
++	hdrlines = 0;
++	p = armor_start;
++	while (p < armor_end && *p != '\n' && *p != '\r')
++	{
++		p = memchr(p, '\n', armor_end - p);
++		if (!p)
++			return PXE_PGP_CORRUPT_ARMOR;
++
++		/* step to start of next line */
++		p++;
++		hdrlines++;
++	}
++	base64_start = p;
++
++	/*
++	 * Make a modifiable copy of the part of the input that contains the
++	 * headers. The returned key/value pointers will point inside the buffer.
++	 */
++	armor_len = base64_start - armor_start;
++	buf = palloc(armor_len + 1);
++	memcpy(buf, armor_start, armor_len);
++	buf[armor_len] = '\0';
++
++	/* Allocate return arrays */
++	*keys = (char **) palloc(hdrlines * sizeof(char *));
++	*values = (char **) palloc(hdrlines * sizeof(char *));
++
++	/*
++	 * Split the header lines at newlines and ": " separators, and collect
++	 * pointers to the keys and values in the return arrays.
++	 */
++	n = 0;
++	line = buf;
++	for (;;)
++	{
++		/* find end of line */
++		eol = strchr(line, '\n');
++		if (!eol)
++			break;
++		nextline = eol + 1;
++		/* if the line ends in CR + LF, strip the CR */
++		if (eol > line && *(eol - 1) == '\r')
++			eol--;
++		*eol = '\0';
++
++		/* find colon+space separating the key and value */
++		colon = strstr(line, ": ");
++		if (!colon)
++			return PXE_PGP_CORRUPT_ARMOR;
++		*colon = '\0';
++
++		/* shouldn't happen, we counted the number of lines beforehand */
++		if (n >= hdrlines)
++			elog(ERROR, "unexpected number of armor header lines");
++
++		(*keys)[n] = line;
++		(*values)[n] = colon + 2;
++		n++;
++
++		/* step to start of next line */
++		line = nextline;
++	}
++
++	if (n != hdrlines)
++		elog(ERROR, "unexpected number of armor header lines");
++
++	*nheaders = n;
++	return 0;
+ }
 diff --git a/pgp-pgsql.c b/pgp-pgsql.c
-index d4eec03..fe4d20b 100644
+index d4eec03..9cab09a 100644
 --- a/pgp-pgsql.c
 +++ b/pgp-pgsql.c
-@@ -31,8 +31,10 @@
+@@ -31,8 +31,15 @@
  
  #include "postgres.h"
  
++#include "lib/stringinfo.h"
 +#include "catalog/pg_type.h"
  #include "mb/pg_wchar.h"
  #include "utils/builtins.h"
 +#include "utils/array.h"
++#include "funcapi.h"
++#include "utils/memutils.h"
++#include "utils/timestamp.h"
++#include "miscadmin.h"
  
  #include "mbuf.h"
  #include "px.h"
-@@ -55,6 +57,7 @@ Datum		pgp_key_id_w(PG_FUNCTION_ARGS);
+@@ -55,6 +62,7 @@ Datum		pgp_key_id_w(PG_FUNCTION_ARGS);
  
  Datum		pg_armor(PG_FUNCTION_ARGS);
  Datum		pg_dearmor(PG_FUNCTION_ARGS);
-+Datum		pgp_armor_header_w(PG_FUNCTION_ARGS);
++Datum		pgp_armor_headers(PG_FUNCTION_ARGS);
  
  /* function headers */
  
-@@ -72,6 +75,7 @@ PG_FUNCTION_INFO_V1(pgp_key_id_w);
+@@ -72,6 +80,7 @@ PG_FUNCTION_INFO_V1(pgp_key_id_w);
  
  PG_FUNCTION_INFO_V1(pg_armor);
  PG_FUNCTION_INFO_V1(pg_dearmor);
-+PG_FUNCTION_INFO_V1(pgp_armor_header_w);
++PG_FUNCTION_INFO_V1(pgp_armor_headers);
  
  /*
   * Mix a block of data into RNG.
-@@ -832,6 +836,68 @@ pgp_pub_decrypt_text(PG_FUNCTION_ARGS)
+@@ -164,6 +173,19 @@ convert_to_utf8(text *src)
+ 	return convert_charset(src, GetDatabaseEncoding(), PG_UTF8);
+ }
+ 
++static bool
++string_is_ascii(const char *str)
++{
++	const char *p;
++
++	for (p = str; *p; p++)
++	{
++		if (IS_HIGHBIT_SET(*p))
++			return false;
++	}
++	return true;
++}
++
+ static void
+ clear_and_pfree(text *p)
+ {
+@@ -832,28 +854,133 @@ pgp_pub_decrypt_text(PG_FUNCTION_ARGS)
   * Wrappers for PGP ascii armor
   */
  
++/*
++ * Helper function for pgp_armor. Converts arrays of keys and values into
++ * plain C arrays, and checks that they don't contain invalid characters.
++ */
 +static int
 +parse_key_value_arrays(ArrayType *key_array, ArrayType *val_array,
 +					   char ***p_keys, char ***p_values)
@@ -510,18 +681,18 @@ index d4eec03..fe4d20b 100644
 +	if (nkdims == 0)
 +		return 0;
 +
-+    deconstruct_array(key_array,
-+                      TEXTOID, -1, false, 'i',
-+                      &key_datums, &key_nulls, &key_count);
++	deconstruct_array(key_array,
++					  TEXTOID, -1, false, 'i',
++					  &key_datums, &key_nulls, &key_count);
 +
-+    deconstruct_array(val_array,
-+                      TEXTOID, -1, false, 'i',
-+                      &val_datums, &val_nulls, &val_count);
++	deconstruct_array(val_array,
++					  TEXTOID, -1, false, 'i',
++					  &val_datums, &val_nulls, &val_count);
 +
-+    if (key_count != val_count)
-+        ereport(ERROR,
-+                (errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR),
-+                 errmsg("mismatched array dimensions")));
++	if (key_count != val_count)
++		ereport(ERROR,
++				(errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR),
++				 errmsg("mismatched array dimensions")));
 +
 +	keys = (char **) palloc(sizeof(char *) * key_count);
 +	values = (char **) palloc(sizeof(char *) * val_count);
@@ -530,18 +701,46 @@ index d4eec03..fe4d20b 100644
 +	{
 +		char *v;
 +
++		/* Check that the key doesn't contain anything funny */
 +		if (key_nulls[i])
 +			ereport(ERROR,
 +					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 +					 errmsg("null value not allowed for header key")));
++
++		v = TextDatumGetCString(key_datums[i]);
++
++		if (!string_is_ascii(v))
++			ereport(ERROR,
++					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
++					 errmsg("header key must not contain non-ASCII characters")));
++		if (strstr(v, ": "))
++			ereport(ERROR,
++					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
++					 errmsg("header key must not contain \": \"")));
++		if (strchr(v, '\n'))
++			ereport(ERROR,
++					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
++					 errmsg("header key must not contain newlines")));
++		keys[i] = v;
++
++		/* And the same for the value */
 +		if (val_nulls[i])
 +			ereport(ERROR,
 +					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
 +					 errmsg("null value not allowed for header value")));
-+		v = TextDatumGetCString(key_datums[i]);
-+		keys[i] = pg_server_to_any(v, strlen(v), PG_UTF8);
++
 +		v = TextDatumGetCString(val_datums[i]);
-+		values[i] = pg_server_to_any(v, strlen(v), PG_UTF8);
++
++		if (!string_is_ascii(v))
++			ereport(ERROR,
++					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
++					 errmsg("header value must not contain non-ASCII characters")));
++		if (strchr(v, '\n'))
++			ereport(ERROR,
++					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
++					 errmsg("header value must not contain newlines")));
++
++		values[i] = v;
 +	}
 +
 +	*p_keys = keys;
@@ -552,11 +751,14 @@ index d4eec03..fe4d20b 100644
  Datum
  pg_armor(PG_FUNCTION_ARGS)
  {
-@@ -840,15 +906,27 @@ pg_armor(PG_FUNCTION_ARGS)
- 	int			data_len,
- 				res_len,
- 				guess_len;
-+	int			num_headers = 0;
+ 	bytea	   *data;
+ 	text	   *res;
+-	int			data_len,
+-				res_len,
+-				guess_len;
++	int			data_len;
++	StringInfoData buf;
++	int			num_headers;
 +	char	  **keys = NULL,
 +			  **values = NULL;
  
@@ -568,63 +770,144 @@ index d4eec03..fe4d20b 100644
 +											 PG_GETARG_ARRAYTYPE_P(2),
 +											 &keys, &values);
 +	}
-+	else if (PG_NARGS() != 1)
++	else if (PG_NARGS() == 1)
++		num_headers = 0;
++	else
 +		elog(ERROR, "unexpected number of arguments %d", PG_NARGS());
  
 -	guess_len = pgp_armor_enc_len(data_len);
-+	guess_len = pgp_armor_enc_len(data_len, num_headers, keys, values);
- 	res = palloc(VARHDRSZ + guess_len);
+-	res = palloc(VARHDRSZ + guess_len);
++	initStringInfo(&buf);
  
- 	res_len = pgp_armor_encode((uint8 *) VARDATA(data), data_len,
+-	res_len = pgp_armor_encode((uint8 *) VARDATA(data), data_len,
 -							   (uint8 *) VARDATA(res));
-+							   (uint8 *) VARDATA(res),
-+							   num_headers, keys, values);
- 	if (res_len > guess_len)
+-	if (res_len > guess_len)
+-		ereport(ERROR,
+-				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
+-				 errmsg("Overflow - encode estimate too small")));
+-	SET_VARSIZE(res, VARHDRSZ + res_len);
++	pgp_armor_encode((uint8 *) VARDATA(data), data_len, &buf,
++					 num_headers, keys, values);
++
++	res = palloc(VARHDRSZ + buf.len);
++	SET_VARSIZE(res, VARHDRSZ + buf.len);
++	memcpy(VARDATA(res), buf.data, buf.len);
++	pfree(buf.data);
+ 
+ 	PG_FREE_IF_COPY(data, 0);
+ 	PG_RETURN_TEXT_P(res);
+@@ -864,32 +991,105 @@ pg_dearmor(PG_FUNCTION_ARGS)
+ {
+ 	text	   *data;
+ 	bytea	   *res;
+-	int			data_len,
+-				res_len,
+-				guess_len;
++	int			data_len;
++	int			ret;
++	StringInfoData buf;
+ 
+ 	data = PG_GETARG_TEXT_P(0);
+ 	data_len = VARSIZE(data) - VARHDRSZ;
+ 
+-	guess_len = pgp_armor_dec_len(data_len);
+-	res = palloc(VARHDRSZ + guess_len);
++	initStringInfo(&buf);
+ 
+-	res_len = pgp_armor_decode((uint8 *) VARDATA(data), data_len,
+-							   (uint8 *) VARDATA(res));
+-	if (res_len < 0)
++	ret = pgp_armor_decode((uint8 *) VARDATA(data), data_len, &buf);
++	if (ret < 0)
  		ereport(ERROR,
  				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
-@@ -890,6 +968,50 @@ pg_dearmor(PG_FUNCTION_ARGS)
+-				 errmsg("%s", px_strerror(res_len))));
+-	if (res_len > guess_len)
+-		ereport(ERROR,
+-				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
+-				 errmsg("Overflow - decode estimate too small")));
+-	SET_VARSIZE(res, VARHDRSZ + res_len);
++				 errmsg("%s", px_strerror(ret))));
++	res = palloc(VARHDRSZ + buf.len);
++	SET_VARSIZE(res, VARHDRSZ + buf.len);
++	memcpy(VARDATA(res), buf.data, buf.len);
++	pfree(buf.data);
+ 
+ 	PG_FREE_IF_COPY(data, 0);
  	PG_RETURN_TEXT_P(res);
  }
  
-+Datum
-+pgp_armor_header_w(PG_FUNCTION_ARGS)
++/* cross-call state for pgp_armor_headers */
++typedef struct
 +{
-+	bytea	   *data;
-+	int			data_len,
-+				res;
-+	char	   *buf;
-+	text	   *key,
-+			   *utf8key;
-+	int			buflen;
++	int			nheaders;
++	char	  **keys;
++	char	  **values;
++} pgp_armor_headers_state;
 +
-+	data = PG_GETARG_BYTEA_P(0);
-+	data_len = VARSIZE(data) - VARHDRSZ;
++Datum
++pgp_armor_headers(PG_FUNCTION_ARGS)
++{
++	FuncCallContext *funcctx;
++	pgp_armor_headers_state *state;
++	char	   *utf8key;
++	char	   *utf8val;
++	HeapTuple	tuple;
++	TupleDesc	tupdesc;
++	AttInMetadata *attinmeta;
 +
-+	key = PG_GETARG_TEXT_P(1);
-+	utf8key = convert_to_utf8(key);
-+	res = pgp_armor_header((uint8 *) VARDATA(data), data_len,
-+							VARDATA(utf8key), VARSIZE(utf8key) - VARHDRSZ,
-+							(uint8 **) &buf, &buflen);
-+	if (res < 0)
-+		ereport(ERROR,
-+				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
-+				 errmsg("%s", px_strerror(res))));
++	if (SRF_IS_FIRSTCALL())
++	{
++		text	   *data = PG_GETARG_TEXT_PP(0);
++		int			res;
++		MemoryContext oldcontext;
 +
-+	PG_FREE_IF_COPY(data, 0);
-+	if (utf8key != key)
-+		pfree(utf8key);
-+	PG_FREE_IF_COPY(key, 1);
-+	if (!buf)
-+		PG_RETURN_NULL();
++		funcctx = SRF_FIRSTCALL_INIT();
++
++		/* we need the state allocated in the multi call context */
++		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
++
++		/* Build a tuple descriptor for our result type */
++		if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
++			elog(ERROR, "return type must be a row type");
++
++		attinmeta = TupleDescGetAttInMetadata(tupdesc);
++		funcctx->attinmeta = attinmeta;
++
++		state = (pgp_armor_headers_state *) palloc(sizeof(pgp_armor_headers_state));
++
++		res = pgp_extract_armor_headers((uint8 *) VARDATA_ANY(data),
++										VARSIZE_ANY_EXHDR(data),
++										&state->nheaders, &state->keys,
++										&state->values);
++		if (res < 0)
++			ereport(ERROR,
++					(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
++					 errmsg("%s", px_strerror(res))));
++
++		MemoryContextSwitchTo(oldcontext);
++		funcctx->user_fctx = state;
++	}
++
++	funcctx = SRF_PERCALL_SETUP();
++	state = (pgp_armor_headers_state *) funcctx->user_fctx;
++
++	if (funcctx->call_cntr >= state->nheaders)
++		SRF_RETURN_DONE(funcctx);
 +	else
 +	{
-+		/* assume it's UTF-8 */
-+		char *utf;
-+		text *result;
++		char	  *values[2];
 +
-+		utf = pg_any_to_server(buf, buflen, PG_UTF8);
-+		result = cstring_to_text(utf);
-+		PG_RETURN_TEXT_P(result);
++		/* we assume that the keys (and values) are in UTF-8. */
++		utf8key = state->keys[funcctx->call_cntr];
++		utf8val = state->values[funcctx->call_cntr];
++
++		values[0] = pg_any_to_server(utf8key, strlen(utf8key), PG_UTF8);
++		values[1] = pg_any_to_server(utf8val, strlen(utf8val), PG_UTF8);
++
++		/* build a tuple */
++		tuple = BuildTupleFromCStrings(funcctx->attinmeta, values);
++		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
 +	}
 +}
 +
@@ -634,129 +917,134 @@ index d4eec03..fe4d20b 100644
   * Wrappers for PGP key id
   */
 diff --git a/pgp.h b/pgp.h
-index 3022abf..b9574fa 100644
+index 3022abf..7ad9d70 100644
 --- a/pgp.h
 +++ b/pgp.h
-@@ -271,9 +271,13 @@ void		pgp_cfb_free(PGP_CFB *ctx);
+@@ -29,6 +29,11 @@
+  * contrib/pgcrypto/pgp.h
+  */
+ 
++#include "lib/stringinfo.h"
++
++#include "mbuf.h"
++#include "px.h"
++
+ enum PGP_S2K_TYPE
+ {
+ 	PGP_S2K_SIMPLE = 0,
+@@ -271,10 +276,11 @@ void		pgp_cfb_free(PGP_CFB *ctx);
  int			pgp_cfb_encrypt(PGP_CFB *ctx, const uint8 *data, int len, uint8 *dst);
  int			pgp_cfb_decrypt(PGP_CFB *ctx, const uint8 *data, int len, uint8 *dst);
  
 -int			pgp_armor_encode(const uint8 *src, unsigned len, uint8 *dst);
-+int			pgp_armor_encode(const uint8 *src, unsigned len, uint8 *dst,
-+							 int num_headers, char **keys, char **values);
- int			pgp_armor_decode(const uint8 *src, unsigned len, uint8 *dst);
+-int			pgp_armor_decode(const uint8 *src, unsigned len, uint8 *dst);
 -unsigned	pgp_armor_enc_len(unsigned len);
-+int			pgp_armor_header(const uint8 *src, unsigned len,
-+							 const char *key, unsigned key_len,
-+							 uint8 **dst, int *out_len);
-+unsigned	pgp_armor_enc_len(unsigned len, int num_headers, char **keys, char **values);
- unsigned	pgp_armor_dec_len(unsigned len);
+-unsigned	pgp_armor_dec_len(unsigned len);
++void		pgp_armor_encode(const uint8 *src, unsigned len, StringInfo dst,
++							 int num_headers, char **keys, char **values);
++int			pgp_armor_decode(const uint8 *src, int len, StringInfo dst);
++int			pgp_extract_armor_headers(const uint8 *src, unsigned len,
++									  int *nheaders, char ***keys, char ***values);
  
  int			pgp_compress_filter(PushFilter **res, PGP_Context *ctx, PushFilter *dst);
+ int			pgp_decompress_filter(PullFilter **res, PGP_Context *ctx, PullFilter *src);
 diff --git a/sql/pgp-armor.sql b/sql/pgp-armor.sql
-index 71ffba2..e62f024 100644
+index 71ffba2..ae4fbad 100644
 --- a/sql/pgp-armor.sql
 +++ b/sql/pgp-armor.sql
-@@ -56,3 +56,161 @@ em9va2E=
+@@ -56,3 +56,197 @@ em9va2E=
  =ZZZZ
  -----END PGP MESSAGE-----
  ');
 +
-+-- corrupt
-+select pgp_armor_header('
++-- corrupt (no space after the colon)
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +foo:
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'foo');
++');
 +
-+-- empty
-+select pgp_armor_header('
++-- corrupt (no empty line)
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++
++-- no headers
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++
++-- header with empty value
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +foo: 
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'foo');
++');
 +
 +-- simple
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
-+foo: bar
++fookey: foovalue
++barkey: barvalue
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'foo');
-+
-+-- uninteresting keys, part 1
-+select pgp_armor_header('
-+-----BEGIN PGP MESSAGE-----
-+foo: found
-+bar: ignored
-+
-+em9va2E=
-+=ZZZZ
-+-----END PGP MESSAGE-----
-+', 'foo');
-+
-+-- uninteresting keys, part 2
-+select pgp_armor_header('
-+-----BEGIN PGP MESSAGE-----
-+bar: ignored
-+foo: found
-+
-+em9va2E=
-+=ZZZZ
-+-----END PGP MESSAGE-----
-+', 'foo');
-+
-+-- uninteresting keys, part 3
-+select pgp_armor_header('
-+-----BEGIN PGP MESSAGE-----
-+bar: ignored
-+foo: found
-+bar: ignored
-+
-+em9va2E=
-+=ZZZZ
-+-----END PGP MESSAGE-----
-+', 'foo');
++');
 +
 +-- insane keys, part 1
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +insane:key : 
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'insane:key ');
++');
 +
 +-- insane keys, part 2
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +insane:key : text value here
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'insane:key ');
++');
 +
 +-- long value
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +long: this value is more than 76 characters long, but it should still parse correctly as that''s permitted by RFC 4880
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
-+', 'long');
++');
 +
 +-- long value, split up
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++long: this value is more than 76 characters long, but it should still 
++long: parse correctly as that''s permitted by RFC 4880
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
 +select pgp_armor_header('
 +-----BEGIN PGP MESSAGE-----
 +long: this value is more than 76 characters long, but it should still 
@@ -767,8 +1055,19 @@ index 71ffba2..e62f024 100644
 +-----END PGP MESSAGE-----
 +', 'long');
 +
++
 +-- long value, split up, part 2
-+select pgp_armor_header('
++select * from pgp_armor_headers('
++-----BEGIN PGP MESSAGE-----
++long: this value is more than 
++long: 76 characters long, but it should still 
++long: parse correctly as that''s permitted by RFC 4880
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++select * from pgp_armor_header('
 +-----BEGIN PGP MESSAGE-----
 +long: this value is more than 
 +long: 76 characters long, but it should still 
@@ -778,24 +1077,40 @@ index 71ffba2..e62f024 100644
 +=ZZZZ
 +-----END PGP MESSAGE-----
 +', 'long');
++
 +
 +-- long value, split up, part 3
-+select pgp_armor_header('
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
-+ignored: 
++emptykey: 
 +long: this value is more than 
-+ignored: 
++emptykey: 
 +long: 76 characters long, but it should still 
-+ignored: 
++emptykey: 
 +long: parse correctly as that''s permitted by RFC 4880
-+ignored: 
++emptykey: 
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++');
++select * from pgp_armor_header('
++-----BEGIN PGP MESSAGE-----
++emptykey: 
++long: this value is more than 
++emptykey: 
++long: 76 characters long, but it should still 
++emptykey: 
++long: parse correctly as that''s permitted by RFC 4880
++emptykey: 
 +
 +em9va2E=
 +=ZZZZ
 +-----END PGP MESSAGE-----
 +', 'long');
 +
-+select pgp_armor_header('
++
++select * from pgp_armor_headers('
 +-----BEGIN PGP MESSAGE-----
 +Comment: dat1.blowfish.sha1.mdc.s2k3.z0
 +
@@ -803,12 +1118,25 @@ index 71ffba2..e62f024 100644
 +yA6Ce1QTMK3KdL2MPfamsTUSAML8huCJMwYQFfE=
 +=JcP+
 +-----END PGP MESSAGE-----
-+', 'Comment');
++');
++
++-- test CR+LF line endings
++select * from pgp_armor_headers(replace('
++-----BEGIN PGP MESSAGE-----
++fookey: foovalue
++barkey: barvalue
++
++em9va2E=
++=ZZZZ
++-----END PGP MESSAGE-----
++', E'\n', E'\r\n'));
 +
 +-- test header generation
 +select armor('zooka', array['foo'], array['bar']);
-+select armor('zooka', array['Version', 'Comment'], array['Created by pgcrypto', 'PostgreSQL, the world''s most most advanced open source database']);
-+select pgp_armor_header(armor('zooka', array['Version', 'Comment'], array['Created by pgcrypto', 'PostgreSQL, the world''s most most advanced open source database']), 'Comment');
++select armor('zooka', array['Version', 'Comment'], array['Created by pgcrypto', 'PostgreSQL, the world''s most advanced open source database']);
++select * from pgp_armor_headers(
++  armor('zooka', array['Version', 'Comment'],
++                 array['Created by pgcrypto', 'PostgreSQL, the world''s most advanced open source database']));
 +
 +-- error/corner cases
 +select armor('', array['foo'], array['too', 'many']);
@@ -819,3 +1147,6 @@ index 71ffba2..e62f024 100644
 +select armor('', array['foo'], array[null]);
 +select armor('', '[0:0]={"foo"}', array['foo']);
 +select armor('', array['foo'], '[0:0]={"foo"}');
++select armor('', array[E'embedded\nnewline'], array['foo']);
++select armor('', array['foo'], array[E'embedded\nnewline']);
++select armor('', array['embedded: colon+space'], array['foo']);

--- a/debian/postgresql-pgcrypto-openpgp/patches/9/111-pgp-signatures.patch
+++ b/debian/postgresql-pgcrypto-openpgp/patches/9/111-pgp-signatures.patch
@@ -130,10 +130,10 @@ index 1fe0088..5395135 100644
 +
 diff --git a/expected/pgp-sign.out b/expected/pgp-sign.out
 new file mode 100644
-index 0000000..ca46a27
+index 0000000..66f202a
 --- /dev/null
 +++ b/expected/pgp-sign.out
-@@ -0,0 +1,337 @@
+@@ -0,0 +1,365 @@
 +--
 +-- PGP sign
 +--
@@ -261,6 +261,7 @@ index 0000000..ca46a27
 +=snSk
 +-----END PGP MESSAGE-----
 +');
++-- multiple signers without verifying the signature
 +select * from pgp_pub_decrypt_bytea((select dearmor(data) from encdata where id=6), (select dearmor(seckey) from keytbl where keytbl.name = 'rsaenc2048'));
 + pgp_pub_decrypt_bytea 
 +-----------------------
@@ -337,6 +338,33 @@ index 0000000..ca46a27
 + pgp_pub_decrypt_verify_bytea 
 +------------------------------
 + hello world
++(1 row)
++
++-- test for MDC filter in pgp-info
++insert into encdata(id, data) values (8, '
++-----BEGIN PGP MESSAGE-----
++
++hQEMA/0CBsQJt0h1AQf9Ft3w02xcBLxXvKhlQwpngOr3+yYwvUNf2Cup9eDuk52RR0dQ8A/lAW5Q
++6xvidlsUqpym7dG7l1siiit8xWv4wqlk+Aoyf5AOIa90nptKm9m/s7PPLjySRSy4Upyb/lm4686R
++Yw/DtOMV5Y8CDj1W0KzSy4RJFDh3F5e0wlPfci2fpfjz6j4Ac/XQWyBXz0bEqAhGa7U1slO1Z2af
++0F4fbSu17XG20erPPfusoKjkFfcQTxO34uj5HUQbjKbOgWcTnsdz7OLZFZ3fjEbQqG4YtEwvQ5dC
++XVN2rST6WQRIMMlr95WoX0agI3ykEZ/vy8Sh+Iji5PPM6UOaQqS5Aw1fvdLpAeYo7yNjAaIfx5xH
++b+fhfgGgKjSGQJYv8Dp5b3uXN7o3I0YSGyLDRkAgZD+d+5w75P+oJESYLLzlDrcaJ+0YvDEzbalV
+++0vp9cKIGXsQ82FEzAq6RrlRM9HBVwyMMvMAo18py5ruSDckLdLuS05GobtiZvZpV+j+/TSr+GXn
++/1B8XwCE829Ty4PT2GrD9e3oa1yedM17FPDtesMFLlxpVKeP89jWbn1U0gTvp5QFiLINyka5Uh71
++5xsBy8KG7+ZQ1bppvgH8sSos7s8VkbyS5/3C6nWoUN7ylzVh4d2Jb60Nqx+rtHOpdOfH7e+55Dux
++NwU0nNni5msv++QQoKwr5guMQ+j0CofQlW8VA82S/fmYQEyifuCVA/qb0OK4qBN9gne8hePEbplV
++pNcuodLkeBPiRSK2G+zdp0yYEpeMV5C1hxYVMS1ea0BoKMq5n57jwmnnLwJijjUw6CjGodtBF7mT
++aEHeff1OPHgjbFtXojDuPAaN86RTRXqN6HSOrv/V8eW78KoEUENcOVDLvoOYpUlqGdmSp0HGpuDZ
++U1Hp14vpvabDrjZ45VxZKSdLGeywyVkYkV4ZeXXsurbOCGwUzgZBodHcaG1fSF7NBTDPrXNfkr1n
++oDruf0xBGr6adDlBmXWCo6AeKdCfuJJ9s0KUi0LbNaewpuyYiT8t3ziqdjcCnUs=
++=26/O
++-----END PGP MESSAGE-----
++');
++select * from pgp_pub_signatures((select dearmor(data) from encdata where id=8), (select dearmor(seckey) from keytbl where keytbl.name = 'rsaenc2048'), '', TRUE);
++      keyid       | digest | pubkeyalgo |        creation_time         
++------------------+--------+------------+------------------------------
++ 9DCF8E9C9BD31F24 | sha1   | rsa        | Sat Nov 01 03:02:52 2014 PDT
 +(1 row)
 +
 +-- pgp_main_key_id() should fail, even on signed data
@@ -624,12 +652,12 @@ index da016c0..c227bdd 100644
  
  #define GETBYTE(pf, dst) \
 diff --git a/pgcrypto_openpgp--1.2.sql b/pgcrypto_openpgp--1.2.sql
-index 4debd7e..7152293 100644
+index 8b5e918..c6124a2 100644
 --- a/pgcrypto_openpgp--1.2.sql
 +++ b/pgcrypto_openpgp--1.2.sql
-@@ -215,3 +215,226 @@ RETURNS text
- AS 'MODULE_PATHNAME', 'pgp_armor_header_w'
- LANGUAGE C IMMUTABLE STRICT;
+@@ -222,3 +222,226 @@ SELECT string_agg(h.value, '') FROM pgp_armor_headers($1) h WHERE h.key = $2
+ $$
+ LANGUAGE sql IMMUTABLE STRICT;
  
 +--
 +-- pgcrypto_signatures
@@ -855,7 +883,7 @@ index 4debd7e..7152293 100644
 +AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
 +LANGUAGE C IMMUTABLE STRICT;
 diff --git a/pgp-decrypt.c b/pgp-decrypt.c
-index c9aa6cd..9c6dac3 100644
+index c9aa6cd..2491726 100644
 --- a/pgp-decrypt.c
 +++ b/pgp-decrypt.c
 @@ -155,7 +155,15 @@ pgp_parse_pkt_hdr(PullFilter *src, uint8 *tag, int *len_p, int allow_ctx)
@@ -882,6 +910,24 @@ index c9aa6cd..9c6dac3 100644
 -static struct PullFilterOps prefix_filter = {
 +struct PullFilterOps pgp_prefix_filter = {
  	prefix_init, NULL, NULL
+ };
+ 
+@@ -433,7 +441,7 @@ mdc_read(void *priv, PullFilter *src, int len,
+ 	return res;
+ }
+ 
+-static struct PullFilterOps mdc_filter = {
++struct PullFilterOps pgp_mdc_filter = {
+ 	mdc_init, mdc_read, mdc_free
+ };
+ 
+@@ -597,7 +605,7 @@ mdcbuf_free(void *priv)
+ 	px_free(st);
+ }
+ 
+-static struct PullFilterOps mdcbuf_filter = {
++struct PullFilterOps pgp_mdcbuf_filter = {
+ 	mdcbuf_init, mdcbuf_read, mdcbuf_free
  };
  
 @@ -638,8 +646,8 @@ decrypt_key(PGP_Context *ctx, const uint8 *src, int len)
@@ -1007,6 +1053,15 @@ index c9aa6cd..9c6dac3 100644
  process_data_packets(PGP_Context *ctx, MBuf *dst, PullFilter *src,
  					 int allow_compr, int need_mdc)
  {
+@@ -896,7 +995,7 @@ process_data_packets(PGP_Context *ctx, MBuf *dst, PullFilter *src,
+ 
+ 		/* context length inside SYMENC_MDC needs special handling */
+ 		if (need_mdc && res == PKT_CONTEXT)
+-			res = pullf_create(&pkt, &mdcbuf_filter, ctx, src);
++			res = pullf_create(&pkt, &pgp_mdcbuf_filter, ctx, src);
+ 		else
+ 			res = pgp_create_pkt_reader(&pkt, src, len, res, ctx);
+ 		if (res < 0)
 @@ -905,8 +1004,17 @@ process_data_packets(PGP_Context *ctx, MBuf *dst, PullFilter *src,
  		switch (tag)
  		{
@@ -1049,7 +1104,12 @@ index c9aa6cd..9c6dac3 100644
  	if (res < 0)
  		goto out;
  
-@@ -1038,7 +1152,7 @@ parse_symenc_mdc_data(PGP_Context *ctx, PullFilter *pkt, MBuf *dst)
+@@ -1034,11 +1148,11 @@ parse_symenc_mdc_data(PGP_Context *ctx, PullFilter *pkt, MBuf *dst)
+ 	if (res < 0)
+ 		goto out;
+ 
+-	res = pullf_create(&pf_mdc, &mdc_filter, ctx, pf_decrypt);
++	res = pullf_create(&pf_mdc, &pgp_mdc_filter, ctx, pf_decrypt);
  	if (res < 0)
  		goto out;
  
@@ -1252,7 +1312,7 @@ index 3b9b5d2..78dc9eb 100644
  	/* text conversion? */
  	if (ctx->text_mode && ctx->convert_crlf)
 diff --git a/pgp-info.c b/pgp-info.c
-index b75266f..15d5a13 100644
+index b75266f..e362409 100644
 --- a/pgp-info.c
 +++ b/pgp-info.c
 @@ -49,17 +49,18 @@ read_pubkey_keyid(PullFilter *pkt, uint8 *keyid_buf)
@@ -1276,7 +1336,7 @@ index b75266f..15d5a13 100644
  	}
  
  err:
-@@ -102,14 +103,215 @@ print_key(uint8 *keyid, char *dst)
+@@ -102,14 +103,231 @@ print_key(uint8 *keyid, char *dst)
  	return 8 * 2;
  }
  
@@ -1288,6 +1348,7 @@ index b75266f..15d5a13 100644
 +extract_signatures(PGP_Context *ctx, PullFilter *src, void *opaque,
 +				   signature_cb_type sig_cb,
 +				   int extract_details,
++				   int need_mdc,
 +				   int allow_compr);
 +
 +
@@ -1306,8 +1367,8 @@ index b75266f..15d5a13 100644
 +	switch (type)
 +	{
 +		case PGP_COMPR_NONE:
-+			res = extract_signatures(ctx, pf_decompr, opaque,
-+									 sig_key_cb, extract_details, 0);
++			res = extract_signatures(ctx, pkt, opaque,
++									 sig_key_cb, extract_details, 0, 0);
 +			break;
 +
 +		case PGP_COMPR_ZIP:
@@ -1316,7 +1377,7 @@ index b75266f..15d5a13 100644
 +			if (res >= 0)
 +			{
 +				res = extract_signatures(ctx, pf_decompr, opaque,
-+										 sig_key_cb, extract_details, 0);
++										 sig_key_cb, extract_details, 0, 0);
 +				pullf_free(pf_decompr);
 +			}
 +			break;
@@ -1334,10 +1395,14 @@ index b75266f..15d5a13 100644
 +	return res;
 +}
 +
++// "Context length" type packet
++#define PKT_CONTEXT 3
++
 +static int
 +extract_signatures(PGP_Context *ctx, PullFilter *src, void *opaque,
 +				   signature_cb_type sig_cb,
 +				   int extract_details,
++				   int need_mdc,
 +				   int allow_compr)
 +{
 +	int			res;
@@ -1349,16 +1414,15 @@ index b75266f..15d5a13 100644
 +
 +	while (1)
 +	{
-+		/*
-+		 * We don't need to care about the special handling for PKG_CONTEXT
-+		 * length in SYMENC_MDC packets because we skip over the data and never
-+		 * check the MDC.
-+		 */
 +		res = pgp_parse_pkt_hdr(src, &tag, &len, 1);
 +		if (res <= 0)
 +			break;
 +
-+		res = pgp_create_pkt_reader(&pkt, src, len, res, NULL);
++		/* context length inside SYMENC_MDC needs special handling */
++		if (need_mdc && res == PKT_CONTEXT)
++			res = pullf_create(&pkt, &pgp_mdcbuf_filter, ctx, src);
++		else
++			res = pgp_create_pkt_reader(&pkt, src, len, res, NULL);
 +		if (res < 0)
 +			break;
 +
@@ -1444,8 +1508,10 @@ index b75266f..15d5a13 100644
 +	PullFilter *pf_decrypt = NULL;
 +	PullFilter *pf_prefix = NULL;
 +	PullFilter *pf_mdc = NULL;
++	PullFilter *chain_head;
++	int			need_mdc = (tag == PGP_PKT_SYMENCRYPTED_DATA_MDC);
 +
-+	if (tag == PGP_PKT_SYMENCRYPTED_DATA_MDC)
++	if (need_mdc)
 +	{
 +		uint8 ver;
 +
@@ -1469,11 +1535,21 @@ index b75266f..15d5a13 100644
 +	if (res < 0)
 +		goto out;
 +
-+	res = pullf_create(&pf_prefix, &pgp_prefix_filter, ctx, pf_decrypt);
++	if (need_mdc)
++	{
++		res = pullf_create(&pf_mdc, &pgp_mdc_filter, ctx, pf_decrypt);
++		if (res < 0)
++			goto out;
++		chain_head = pf_mdc;
++	}
++	else
++		chain_head = pf_decrypt;
++
++	res = pullf_create(&pf_prefix, &pgp_prefix_filter, ctx, chain_head);
 +	if (res < 0)
 +		goto out;
 +
-+	res = extract_signatures(ctx, pf_prefix, opaque, sig_key_cb, extract_details, 1);
++	res = extract_signatures(ctx, pf_prefix, opaque, sig_key_cb, extract_details, need_mdc, 1);
 +
 +out:
 +	if (pf_prefix)
@@ -1497,7 +1573,7 @@ index b75266f..15d5a13 100644
  {
  	int			res;
  	PullFilter *src;
-@@ -122,6 +324,7 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
+@@ -122,6 +340,7 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
  	int			got_data = 0;
  	uint8		keyid_buf[8];
  	int			got_main_key = 0;
@@ -1505,7 +1581,7 @@ index b75266f..15d5a13 100644
  
  
  	res = pullf_create_mbuf_reader(&src, pgp_data);
-@@ -141,36 +344,57 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
+@@ -141,36 +360,57 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
  		{
  			case PGP_PKT_SECRET_KEY:
  			case PGP_PKT_PUBLIC_KEY:
@@ -1578,7 +1654,7 @@ index b75266f..15d5a13 100644
  			case PGP_PKT_MARKER:
  			case PGP_PKT_TRUST:
  			case PGP_PKT_USER_ID:
-@@ -185,6 +409,9 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
+@@ -185,6 +425,9 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
  		if (pkt)
  			pullf_free(pkt);
  		pkt = NULL;
@@ -1588,7 +1664,7 @@ index b75266f..15d5a13 100644
  
  		if (res < 0 || got_data)
  			break;
-@@ -210,26 +437,106 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
+@@ -210,26 +453,106 @@ pgp_get_keyid(MBuf *pgp_data, char *dst)
  	/*
  	 * if still ok, look what we got
  	 */
@@ -1709,21 +1785,10 @@ index b75266f..15d5a13 100644
 +}
 +
 diff --git a/pgp-pgsql.c b/pgp-pgsql.c
-index c251d3f..d04d1a3 100644
+index 9cab09a..65d54b6 100644
 --- a/pgp-pgsql.c
 +++ b/pgp-pgsql.c
-@@ -35,6 +35,10 @@
- #include "mb/pg_wchar.h"
- #include "utils/builtins.h"
- #include "utils/array.h"
-+#include "funcapi.h"
-+#include "utils/memutils.h"
-+#include "utils/timestamp.h"
-+#include "miscadmin.h"
- 
- #include "mbuf.h"
- #include "px.h"
-@@ -45,15 +49,29 @@
+@@ -50,15 +50,29 @@
   */
  Datum		pgp_sym_encrypt_text(PG_FUNCTION_ARGS);
  Datum		pgp_sym_encrypt_bytea(PG_FUNCTION_ARGS);
@@ -1753,7 +1818,7 @@ index c251d3f..d04d1a3 100644
  
  Datum		pg_armor(PG_FUNCTION_ARGS);
  Datum		pg_dearmor(PG_FUNCTION_ARGS);
-@@ -63,15 +81,26 @@ Datum		pgp_armor_header_w(PG_FUNCTION_ARGS);
+@@ -68,15 +82,26 @@ Datum		pgp_armor_headers(PG_FUNCTION_ARGS);
  
  PG_FUNCTION_INFO_V1(pgp_sym_encrypt_bytea);
  PG_FUNCTION_INFO_V1(pgp_sym_encrypt_text);
@@ -1780,7 +1845,7 @@ index c251d3f..d04d1a3 100644
  
  PG_FUNCTION_INFO_V1(pg_armor);
  PG_FUNCTION_INFO_V1(pg_dearmor);
-@@ -183,6 +212,7 @@ struct debug_expect
+@@ -201,6 +226,7 @@ struct debug_expect
  	int			debug;
  	int			expect;
  	int			cipher_algo;
@@ -1788,7 +1853,7 @@ index c251d3f..d04d1a3 100644
  	int			s2k_mode;
  	int			s2k_cipher_algo;
  	int			s2k_digest_algo;
-@@ -198,6 +228,7 @@ fill_expect(struct debug_expect * ex, int text_mode)
+@@ -216,6 +242,7 @@ fill_expect(struct debug_expect * ex, int text_mode)
  	ex->debug = 0;
  	ex->expect = 0;
  	ex->cipher_algo = -1;
@@ -1796,7 +1861,7 @@ index c251d3f..d04d1a3 100644
  	ex->s2k_mode = -1;
  	ex->s2k_cipher_algo = -1;
  	ex->s2k_digest_algo = -1;
-@@ -220,6 +251,7 @@ static void
+@@ -238,6 +265,7 @@ static void
  check_expect(PGP_Context *ctx, struct debug_expect * ex)
  {
  	EX_CHECK(cipher_algo);
@@ -1804,7 +1869,7 @@ index c251d3f..d04d1a3 100644
  	EX_CHECK(s2k_mode);
  	EX_CHECK(s2k_digest_algo);
  	EX_CHECK(use_sess_key);
-@@ -244,6 +276,8 @@ set_arg(PGP_Context *ctx, char *key, char *val,
+@@ -262,6 +290,8 @@ set_arg(PGP_Context *ctx, char *key, char *val,
  
  	if (strcmp(key, "cipher-algo") == 0)
  		res = pgp_set_cipher_algo(ctx, val);
@@ -1813,7 +1878,7 @@ index c251d3f..d04d1a3 100644
  	else if (strcmp(key, "disable-mdc") == 0)
  		res = pgp_disable_mdc(ctx, atoi(val));
  	else if (strcmp(key, "sess-key") == 0)
-@@ -270,6 +304,11 @@ set_arg(PGP_Context *ctx, char *key, char *val,
+@@ -288,6 +318,11 @@ set_arg(PGP_Context *ctx, char *key, char *val,
  		ex->expect = 1;
  		ex->cipher_algo = pgp_get_cipher_code(val);
  	}
@@ -1825,7 +1890,7 @@ index c251d3f..d04d1a3 100644
  	else if (ex != NULL && strcmp(key, "expect-disable-mdc") == 0)
  	{
  		ex->expect = 1;
-@@ -435,7 +474,8 @@ init_work(PGP_Context **ctx_p, int is_text,
+@@ -453,7 +488,8 @@ init_work(PGP_Context **ctx_p, int is_text,
  
  static bytea *
  encrypt_internal(int is_pubenc, int is_text,
@@ -1835,7 +1900,7 @@ index c251d3f..d04d1a3 100644
  {
  	MBuf	   *src,
  			   *dst;
-@@ -480,22 +520,46 @@ encrypt_internal(int is_pubenc, int is_text,
+@@ -498,22 +534,46 @@ encrypt_internal(int is_pubenc, int is_text,
  		MBuf	   *kbuf = create_mbuf_from_vardata(key);
  
  		err = pgp_set_pubkey(ctx, kbuf,
@@ -1885,7 +1950,7 @@ index c251d3f..d04d1a3 100644
  	if (err)
  	{
  		if (ex.debug)
-@@ -528,7 +592,7 @@ encrypt_internal(int is_pubenc, int is_text,
+@@ -546,7 +606,7 @@ encrypt_internal(int is_pubenc, int is_text,
  
  static bytea *
  decrypt_internal(int is_pubenc, int need_text, text *data,
@@ -1894,7 +1959,7 @@ index c251d3f..d04d1a3 100644
  {
  	int			err;
  	MBuf	   *src = NULL,
-@@ -568,25 +632,47 @@ decrypt_internal(int is_pubenc, int need_text, text *data,
+@@ -586,25 +646,47 @@ decrypt_internal(int is_pubenc, int need_text, text *data,
  			psw_len = VARSIZE(keypsw) - VARHDRSZ;
  		}
  		kbuf = create_mbuf_from_vardata(key);
@@ -1949,7 +2014,7 @@ index c251d3f..d04d1a3 100644
  	if (ex.expect)
  		check_expect(ctx, &ex);
  
-@@ -636,6 +722,160 @@ out:
+@@ -654,6 +736,160 @@ out:
  	return res;
  }
  
@@ -2110,7 +2175,7 @@ index c251d3f..d04d1a3 100644
  /*
   * Wrappers for symmetric-key functions
   */
-@@ -652,7 +892,7 @@ pgp_sym_encrypt_bytea(PG_FUNCTION_ARGS)
+@@ -670,7 +906,7 @@ pgp_sym_encrypt_bytea(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 2)
  		arg = PG_GETARG_BYTEA_P(2);
  
@@ -2119,7 +2184,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -674,7 +914,7 @@ pgp_sym_encrypt_text(PG_FUNCTION_ARGS)
+@@ -692,7 +928,7 @@ pgp_sym_encrypt_text(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 2)
  		arg = PG_GETARG_BYTEA_P(2);
  
@@ -2128,7 +2193,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -683,6 +923,66 @@ pgp_sym_encrypt_text(PG_FUNCTION_ARGS)
+@@ -701,6 +937,66 @@ pgp_sym_encrypt_text(PG_FUNCTION_ARGS)
  	PG_RETURN_TEXT_P(res);
  }
  
@@ -2195,7 +2260,7 @@ index c251d3f..d04d1a3 100644
  
  Datum
  pgp_sym_decrypt_bytea(PG_FUNCTION_ARGS)
-@@ -697,7 +997,7 @@ pgp_sym_decrypt_bytea(PG_FUNCTION_ARGS)
+@@ -715,7 +1011,7 @@ pgp_sym_decrypt_bytea(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 2)
  		arg = PG_GETARG_BYTEA_P(2);
  
@@ -2204,7 +2269,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -719,7 +1019,7 @@ pgp_sym_decrypt_text(PG_FUNCTION_ARGS)
+@@ -737,7 +1033,7 @@ pgp_sym_decrypt_text(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 2)
  		arg = PG_GETARG_BYTEA_P(2);
  
@@ -2213,7 +2278,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -728,6 +1028,66 @@ pgp_sym_decrypt_text(PG_FUNCTION_ARGS)
+@@ -746,6 +1042,66 @@ pgp_sym_decrypt_text(PG_FUNCTION_ARGS)
  	PG_RETURN_TEXT_P(res);
  }
  
@@ -2280,7 +2345,7 @@ index c251d3f..d04d1a3 100644
  /*
   * Wrappers for public-key functions
   */
-@@ -745,7 +1105,7 @@ pgp_pub_encrypt_bytea(PG_FUNCTION_ARGS)
+@@ -763,7 +1119,7 @@ pgp_pub_encrypt_bytea(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 2)
  		arg = PG_GETARG_BYTEA_P(2);
  
@@ -2289,7 +2354,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -767,7 +1127,7 @@ pgp_pub_encrypt_text(PG_FUNCTION_ARGS)
+@@ -785,7 +1141,7 @@ pgp_pub_encrypt_text(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 2)
  		arg = PG_GETARG_BYTEA_P(2);
  
@@ -2298,7 +2363,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -776,6 +1136,65 @@ pgp_pub_encrypt_text(PG_FUNCTION_ARGS)
+@@ -794,6 +1150,65 @@ pgp_pub_encrypt_text(PG_FUNCTION_ARGS)
  	PG_RETURN_TEXT_P(res);
  }
  
@@ -2364,7 +2429,7 @@ index c251d3f..d04d1a3 100644
  
  Datum
  pgp_pub_decrypt_bytea(PG_FUNCTION_ARGS)
-@@ -793,7 +1212,7 @@ pgp_pub_decrypt_bytea(PG_FUNCTION_ARGS)
+@@ -811,7 +1226,7 @@ pgp_pub_decrypt_bytea(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 3)
  		arg = PG_GETARG_BYTEA_P(3);
  
@@ -2373,7 +2438,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -820,7 +1239,7 @@ pgp_pub_decrypt_text(PG_FUNCTION_ARGS)
+@@ -838,7 +1253,7 @@ pgp_pub_decrypt_text(PG_FUNCTION_ARGS)
  	if (PG_NARGS() > 3)
  		arg = PG_GETARG_BYTEA_P(3);
  
@@ -2382,7 +2447,7 @@ index c251d3f..d04d1a3 100644
  
  	PG_FREE_IF_COPY(data, 0);
  	PG_FREE_IF_COPY(key, 1);
-@@ -831,6 +1250,65 @@ pgp_pub_decrypt_text(PG_FUNCTION_ARGS)
+@@ -849,6 +1264,65 @@ pgp_pub_decrypt_text(PG_FUNCTION_ARGS)
  	PG_RETURN_TEXT_P(res);
  }
  
@@ -2448,7 +2513,7 @@ index c251d3f..d04d1a3 100644
  
  /*
   * Wrappers for PGP ascii armor
-@@ -1015,7 +1493,7 @@ pgp_armor_header_w(PG_FUNCTION_ARGS)
+@@ -1091,7 +1565,7 @@ pgp_armor_headers(PG_FUNCTION_ARGS)
  
  
  /*
@@ -2457,22 +2522,19 @@ index c251d3f..d04d1a3 100644
   */
  
  Datum
-@@ -1030,7 +1508,31 @@ pgp_key_id_w(PG_FUNCTION_ARGS)
+@@ -1106,7 +1580,7 @@ pgp_key_id_w(PG_FUNCTION_ARGS)
  	buf = create_mbuf_from_vardata(data);
  	res = palloc(VARHDRSZ + 17);
  
 -	res_len = pgp_get_keyid(buf, VARDATA(res));
 +	res_len = pgp_get_keyid(0, buf, VARDATA(res));
-+	mbuf_free(buf);
-+	if (res_len < 0)
-+		ereport(ERROR,
-+				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
-+				 errmsg("%s", px_strerror(res_len))));
-+	SET_VARSIZE(res, VARHDRSZ + res_len);
-+
-+	PG_FREE_IF_COPY(data, 0);
-+	PG_RETURN_TEXT_P(res);
-+}
+ 	mbuf_free(buf);
+ 	if (res_len < 0)
+ 		ereport(ERROR,
+@@ -1117,3 +1591,99 @@ pgp_key_id_w(PG_FUNCTION_ARGS)
+ 	PG_FREE_IF_COPY(data, 0);
+ 	PG_RETURN_TEXT_P(res);
+ }
 +
 +Datum
 +pgp_main_key_id_w(PG_FUNCTION_ARGS)
@@ -2487,13 +2549,16 @@ index c251d3f..d04d1a3 100644
 +	res = palloc(VARHDRSZ + 17);
 +
 +	res_len = pgp_get_keyid(1, buf, VARDATA(res));
- 	mbuf_free(buf);
- 	if (res_len < 0)
- 		ereport(ERROR,
-@@ -1041,3 +1543,75 @@ pgp_key_id_w(PG_FUNCTION_ARGS)
- 	PG_FREE_IF_COPY(data, 0);
- 	PG_RETURN_TEXT_P(res);
- }
++	mbuf_free(buf);
++	if (res_len < 0)
++		ereport(ERROR,
++				(errcode(ERRCODE_EXTERNAL_ROUTINE_INVOCATION_EXCEPTION),
++				 errmsg("%s", px_strerror(res_len))));
++	SET_VARSIZE(res, VARHDRSZ + res_len);
++
++	PG_FREE_IF_COPY(data, 0);
++	PG_RETURN_TEXT_P(res);
++}
 +
 +Datum
 +pgp_sym_signatures_w(PG_FUNCTION_ARGS)
@@ -3734,10 +3799,10 @@ index b8a6bc4..46fcb7c 100644
  {
  	int			code = pgp_get_cipher_code(name);
 diff --git a/pgp.h b/pgp.h
-index b9574fa..31723e8 100644
+index 7ad9d70..93fc980 100644
 --- a/pgp.h
 +++ b/pgp.h
-@@ -42,6 +42,7 @@ enum PGP_PKT_TYPE
+@@ -47,6 +47,7 @@ enum PGP_PKT_TYPE
  	PGP_PKT_PUBENCRYPTED_SESSKEY = 1,
  	PGP_PKT_SIGNATURE = 2,
  	PGP_PKT_SYMENCRYPTED_SESSKEY = 3,
@@ -3745,7 +3810,7 @@ index b9574fa..31723e8 100644
  	PGP_PKT_SECRET_KEY = 5,
  	PGP_PKT_PUBLIC_KEY = 6,
  	PGP_PKT_SECRET_SUBKEY = 7,
-@@ -104,15 +105,29 @@ enum PGP_DIGEST_TYPE
+@@ -109,15 +110,29 @@ enum PGP_DIGEST_TYPE
  	PGP_DIGEST_SHA512 = 10
  };
  
@@ -3775,7 +3840,7 @@ index b9574fa..31723e8 100644
  
  struct PGP_S2K
  {
-@@ -136,6 +151,7 @@ struct PGP_Context
+@@ -141,6 +156,7 @@ struct PGP_Context
  	int			s2k_digest_algo;
  	int			s2k_cipher_algo;
  	int			cipher_algo;
@@ -3783,7 +3848,7 @@ index b9574fa..31723e8 100644
  	int			compress_algo;
  	int			compress_level;
  	int			disable_mdc;
-@@ -153,8 +169,13 @@ struct PGP_Context
+@@ -158,8 +174,13 @@ struct PGP_Context
  	int			use_mdcbuf_filter;
  	PX_MD	   *mdc_ctx;
  
@@ -3799,7 +3864,7 @@ index b9574fa..31723e8 100644
  	int			sym_key_len;
  
  	/*
-@@ -224,17 +245,39 @@ struct PGP_PubKey
+@@ -229,17 +250,39 @@ struct PGP_PubKey
  	int			can_encrypt;
  };
  
@@ -3839,7 +3904,7 @@ index b9574fa..31723e8 100644
  int			pgp_set_s2k_mode(PGP_Context *ctx, int type);
  int			pgp_set_s2k_cipher_algo(PGP_Context *ctx, const char *name);
  int			pgp_set_s2k_digest_algo(PGP_Context *ctx, const char *name);
-@@ -248,10 +291,17 @@ int			pgp_set_unicode_mode(PGP_Context *ctx, int mode);
+@@ -253,10 +296,17 @@ int			pgp_set_unicode_mode(PGP_Context *ctx, int mode);
  int			pgp_get_unicode_mode(PGP_Context *ctx);
  
  int			pgp_set_symkey(PGP_Context *ctx, const uint8 *key, int klen);
@@ -3861,7 +3926,7 @@ index b9574fa..31723e8 100644
  
  /* internal functions */
  
-@@ -287,6 +337,8 @@ int			pgp_key_alloc(PGP_PubKey **pk_p);
+@@ -289,6 +339,8 @@ int			pgp_key_alloc(PGP_PubKey **pk_p);
  void		pgp_key_free(PGP_PubKey *pk);
  int			_pgp_read_public_key(PullFilter *pkt, PGP_PubKey **pk_p);
  
@@ -3870,7 +3935,7 @@ index b9574fa..31723e8 100644
  int			pgp_parse_pubenc_sesskey(PGP_Context *ctx, PullFilter *pkt);
  int pgp_create_pkt_reader(PullFilter **pf_p, PullFilter *src, int len,
  					  int pkttype, PGP_Context *ctx);
-@@ -299,6 +351,14 @@ int			pgp_expect_packet_end(PullFilter *pkt);
+@@ -301,6 +353,14 @@ int			pgp_expect_packet_end(PullFilter *pkt);
  int			pgp_write_pubenc_sesskey(PGP_Context *ctx, PushFilter *dst);
  int			pgp_create_pkt_writer(PushFilter *dst, int tag, PushFilter **res_p);
  
@@ -3885,11 +3950,13 @@ index b9574fa..31723e8 100644
  int			pgp_mpi_alloc(int bits, PGP_MPI **mpi);
  int			pgp_mpi_create(uint8 *data, int bits, PGP_MPI **mpi);
  int			pgp_mpi_free(PGP_MPI *mpi);
-@@ -315,3 +375,4 @@ int			pgp_rsa_encrypt(PGP_PubKey *pk, PGP_MPI *m, PGP_MPI **c);
+@@ -317,3 +377,6 @@ int			pgp_rsa_encrypt(PGP_PubKey *pk, PGP_MPI *m, PGP_MPI **c);
  int			pgp_rsa_decrypt(PGP_PubKey *pk, PGP_MPI *c, PGP_MPI **m);
  
  extern struct PullFilterOps pgp_decrypt_filter;
 +extern struct PullFilterOps pgp_prefix_filter;
++extern struct PullFilterOps pgp_mdc_filter;
++extern struct PullFilterOps pgp_mdcbuf_filter;
 diff --git a/px.c b/px.c
 index f23d4de..6466183 100644
 --- a/px.c
@@ -3972,10 +4039,10 @@ index 8e1d72a..d19911b 100644
 +select pgp_main_key_id(dearmor(seckey)) from keytbl where id=6;
 diff --git a/sql/pgp-sign.sql b/sql/pgp-sign.sql
 new file mode 100644
-index 0000000..9ea8ade
+index 0000000..2863d6d
 --- /dev/null
 +++ b/sql/pgp-sign.sql
-@@ -0,0 +1,211 @@
+@@ -0,0 +1,234 @@
 +--
 +-- PGP sign
 +--
@@ -4079,7 +4146,7 @@ index 0000000..9ea8ade
 +-----END PGP MESSAGE-----
 +');
 +
-+
++-- multiple signers without verifying the signature
 +select * from pgp_pub_decrypt_bytea((select dearmor(data) from encdata where id=6), (select dearmor(seckey) from keytbl where keytbl.name = 'rsaenc2048'));
 +
 +-- no details
@@ -4118,6 +4185,29 @@ index 0000000..9ea8ade
 +-----END PGP MESSAGE-----
 +');
 +select * from pgp_pub_decrypt_verify_bytea((select dearmor(data) from encdata where id=7), (select dearmor(seckey) from keytbl where keytbl.name = 'rsaenc2048'), (select dearmor(pubkey) from keytbl where keytbl.name = 'rsa2048'));
++
++-- test for MDC filter in pgp-info
++insert into encdata(id, data) values (8, '
++-----BEGIN PGP MESSAGE-----
++
++hQEMA/0CBsQJt0h1AQf9Ft3w02xcBLxXvKhlQwpngOr3+yYwvUNf2Cup9eDuk52RR0dQ8A/lAW5Q
++6xvidlsUqpym7dG7l1siiit8xWv4wqlk+Aoyf5AOIa90nptKm9m/s7PPLjySRSy4Upyb/lm4686R
++Yw/DtOMV5Y8CDj1W0KzSy4RJFDh3F5e0wlPfci2fpfjz6j4Ac/XQWyBXz0bEqAhGa7U1slO1Z2af
++0F4fbSu17XG20erPPfusoKjkFfcQTxO34uj5HUQbjKbOgWcTnsdz7OLZFZ3fjEbQqG4YtEwvQ5dC
++XVN2rST6WQRIMMlr95WoX0agI3ykEZ/vy8Sh+Iji5PPM6UOaQqS5Aw1fvdLpAeYo7yNjAaIfx5xH
++b+fhfgGgKjSGQJYv8Dp5b3uXN7o3I0YSGyLDRkAgZD+d+5w75P+oJESYLLzlDrcaJ+0YvDEzbalV
+++0vp9cKIGXsQ82FEzAq6RrlRM9HBVwyMMvMAo18py5ruSDckLdLuS05GobtiZvZpV+j+/TSr+GXn
++/1B8XwCE829Ty4PT2GrD9e3oa1yedM17FPDtesMFLlxpVKeP89jWbn1U0gTvp5QFiLINyka5Uh71
++5xsBy8KG7+ZQ1bppvgH8sSos7s8VkbyS5/3C6nWoUN7ylzVh4d2Jb60Nqx+rtHOpdOfH7e+55Dux
++NwU0nNni5msv++QQoKwr5guMQ+j0CofQlW8VA82S/fmYQEyifuCVA/qb0OK4qBN9gne8hePEbplV
++pNcuodLkeBPiRSK2G+zdp0yYEpeMV5C1hxYVMS1ea0BoKMq5n57jwmnnLwJijjUw6CjGodtBF7mT
++aEHeff1OPHgjbFtXojDuPAaN86RTRXqN6HSOrv/V8eW78KoEUENcOVDLvoOYpUlqGdmSp0HGpuDZ
++U1Hp14vpvabDrjZ45VxZKSdLGeywyVkYkV4ZeXXsurbOCGwUzgZBodHcaG1fSF7NBTDPrXNfkr1n
++oDruf0xBGr6adDlBmXWCo6AeKdCfuJJ9s0KUi0LbNaewpuyYiT8t3ziqdjcCnUs=
++=26/O
++-----END PGP MESSAGE-----
++');
++select * from pgp_pub_signatures((select dearmor(data) from encdata where id=8), (select dearmor(seckey) from keytbl where keytbl.name = 'rsaenc2048'), '', TRUE);
 +
 +-- pgp_main_key_id() should fail, even on signed data
 +select pgp_main_key_id(pgp_sym_encrypt_sign_bytea('Secret.', 'key', dearmor(seckey)))

--- a/debian/postgresql-pgcrypto-openpgp/patches/9/112-pgp-12_13_upgrade.patch
+++ b/debian/postgresql-pgcrypto-openpgp/patches/9/112-pgp-12_13_upgrade.patch
@@ -1,0 +1,956 @@
+diff --git a/Makefile b/Makefile
+index fec848e..33b7d90 100644
+--- a/Makefile
++++ b/Makefile
+@@ -26,7 +26,7 @@ MODULE_big	= pgcrypto_openpgp
+ OBJS		= $(SRCS:.c=.o)
+ 
+ EXTENSION = pgcrypto_openpgp
+-DATA = pgcrypto_openpgp--1.2.sql
++DATA = pgcrypto_openpgp--1.2--1.3.sql pgcrypto_openpgp--1.3.sql
+ 
+ REGRESS = init md5 sha1 hmac-md5 hmac-sha1 blowfish rijndael \
+ 	$(CF_TESTS) \
+diff --git a/pgcrypto_openpgp--1.2--1.3.sql b/pgcrypto_openpgp--1.2--1.3.sql
+new file mode 100644
+index 0000000..f8ecdb3
+--- /dev/null
++++ b/pgcrypto_openpgp--1.2--1.3.sql
+@@ -0,0 +1,20 @@
++/* pgcrypto_openpgp/pgcrypto_openpgp--1.2--1.3.sql */
++
++-- complain if script is sourced in psql, rather than via CREATE EXTENSION
++\echo Use "ALTER EXTENSION pgcrypto UPDATE TO '1.3'" to load this file. \quit
++
++--
++-- pgcrypto_armor_headers
++--
++
++CREATE FUNCTION pgp_armor_headers(text, key OUT text, value OUT text)
++RETURNS SETOF record
++AS 'MODULE_PATHNAME', 'pgp_armor_headers'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE OR REPLACE FUNCTION pgp_armor_header(text, text)
++RETURNS text
++AS $$
++SELECT string_agg(h.value, '') FROM pgp_armor_headers($1) h WHERE h.key = $2
++$$
++LANGUAGE sql IMMUTABLE STRICT;
+diff --git a/pgcrypto_openpgp--1.2.sql b/pgcrypto_openpgp--1.2.sql
+deleted file mode 100644
+index c6124a2..0000000
+--- a/pgcrypto_openpgp--1.2.sql
++++ /dev/null
+@@ -1,447 +0,0 @@
+-/* pgcrypto_openpgp/pgcrypto_openpgp--1.2.sql */
+-
+--- complain if script is sourced in psql, rather than via CREATE EXTENSION
+-\echo Use "CREATE EXTENSION pgcrypto_openpgp" to load this file. \quit
+-
+-CREATE FUNCTION digest(text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_digest'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION digest(bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_digest'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION hmac(text, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_hmac'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION hmac(bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_hmac'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION crypt(text, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pg_crypt'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION gen_salt(text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pg_gen_salt'
+-LANGUAGE C VOLATILE STRICT;
+-
+-CREATE FUNCTION gen_salt(text, int4)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pg_gen_salt_rounds'
+-LANGUAGE C VOLATILE STRICT;
+-
+-CREATE FUNCTION encrypt(bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_encrypt'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION decrypt(bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_decrypt'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION encrypt_iv(bytea, bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_encrypt_iv'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION decrypt_iv(bytea, bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_decrypt_iv'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION gen_random_bytes(int4)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_random_bytes'
+-LANGUAGE C VOLATILE STRICT;
+-
+---
+--- pgp_sym_encrypt(data, key)
+---
+-CREATE FUNCTION pgp_sym_encrypt(text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_sym_encrypt_bytea(bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_sym_encrypt(data, key, args)
+---
+-CREATE FUNCTION pgp_sym_encrypt(text, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_sym_encrypt_bytea(bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_sym_decrypt(data, key)
+---
+-CREATE FUNCTION pgp_sym_decrypt(bytea, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_sym_decrypt_bytea(bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_sym_decrypt(data, key, args)
+---
+-CREATE FUNCTION pgp_sym_decrypt(bytea, text, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_sym_decrypt_bytea(bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_encrypt(data, key)
+---
+-CREATE FUNCTION pgp_pub_encrypt(text, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_pub_encrypt_bytea(bytea, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_pub_encrypt(data, key, args)
+---
+-CREATE FUNCTION pgp_pub_encrypt(text, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_pub_encrypt_bytea(bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_pub_decrypt(data, key)
+---
+-CREATE FUNCTION pgp_pub_decrypt(bytea, bytea)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_decrypt(data, key, psw)
+---
+-CREATE FUNCTION pgp_pub_decrypt(bytea, bytea, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_decrypt(data, key, psw, arg)
+---
+-CREATE FUNCTION pgp_pub_decrypt(bytea, bytea, text, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- PGP key ID
+---
+-CREATE FUNCTION pgp_key_id(bytea)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_key_id_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp armor
+---
+-CREATE FUNCTION armor(bytea)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pg_armor'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION dearmor(text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pg_dearmor'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgcrypto_armor_headers
+---
+-
+-CREATE FUNCTION armor(bytea, text[], text[])
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pg_armor'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_armor_headers(text, key OUT text, value OUT text)
+-RETURNS SETOF record
+-AS 'MODULE_PATHNAME', 'pgp_armor_headers'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_armor_header(text, text)
+-RETURNS text
+-AS $$
+-SELECT string_agg(h.value, '') FROM pgp_armor_headers($1) h WHERE h.key = $2
+-$$
+-LANGUAGE sql IMMUTABLE STRICT;
+-
+---
+--- pgcrypto_signatures
+---
+-
+---
+--- pgp_sym_encrypt_sign(data, key, sigkey)
+---
+-CREATE FUNCTION pgp_sym_encrypt_sign(text, text, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_sym_encrypt_sign_bytea(bytea, text, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_sym_encrypt_sign(data, key, sigkey, psw)
+---
+-CREATE FUNCTION pgp_sym_encrypt_sign(text, text, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_sym_encrypt_sign_bytea(bytea, text, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_sym_encrypt_sign(data, key, sigkey, psw, args)
+---
+-CREATE FUNCTION pgp_sym_encrypt_sign(text, text, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_sym_encrypt_sign_bytea(bytea, text, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_sym_decrypt_verify(data, key, sigkey)
+---
+-CREATE FUNCTION pgp_sym_decrypt_verify(bytea, text, bytea)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_sym_decrypt_verify_bytea(bytea, text, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_sym_decrypt_verify(data, key, sigkey, psw)
+---
+-CREATE FUNCTION pgp_sym_decrypt_verify(bytea, text, bytea, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_sym_decrypt_verify_bytea(bytea, text, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_sym_decrypt_verify(data, key, sigkey, psw, args)
+---
+-CREATE FUNCTION pgp_sym_decrypt_verify(bytea, text, bytea, text, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_sym_decrypt_verify_bytea(bytea, text, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_encrypt_sign(data, key, sigkey)
+---
+-CREATE FUNCTION pgp_pub_encrypt_sign(text, bytea, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_pub_encrypt_sign_bytea(bytea, bytea, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_pub_encrypt_sign(data, key, sigkey, psw)
+---
+-CREATE FUNCTION pgp_pub_encrypt_sign(text, bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_pub_encrypt_sign_bytea(bytea, bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_pub_encrypt_sign(data, key, sigkey, psw, args)
+---
+-CREATE FUNCTION pgp_pub_encrypt_sign(text, bytea, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_text'
+-LANGUAGE C STRICT;
+-
+-CREATE FUNCTION pgp_pub_encrypt_sign_bytea(bytea, bytea, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_bytea'
+-LANGUAGE C STRICT;
+-
+---
+--- pgp_pub_decrypt_verify(data, key, sigkey)
+---
+-CREATE FUNCTION pgp_pub_decrypt_verify(bytea, bytea, bytea)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_pub_decrypt_verify_bytea(bytea, bytea, bytea)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_decrypt_verify(data, key, sigkey, psw)
+---
+-CREATE FUNCTION pgp_pub_decrypt_verify(bytea, bytea, bytea, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_pub_decrypt_verify_bytea(bytea, bytea, bytea, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_decrypt_verify(data, key, sigkey, psw, arg)
+---
+-CREATE FUNCTION pgp_pub_decrypt_verify(bytea, bytea, bytea, text, text)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_text'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+-CREATE FUNCTION pgp_pub_decrypt_verify_bytea(bytea, bytea, bytea, text, text)
+-RETURNS bytea
+-AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_bytea'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_main_key_id(key)
+---
+-CREATE FUNCTION pgp_main_key_id(bytea)
+-RETURNS text
+-AS 'MODULE_PATHNAME', 'pgp_main_key_id_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_sym_signatures(data, key)
+---
+-CREATE FUNCTION pgp_sym_signatures(bytea, text)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_sym_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_sym_signatures(data, key, details)
+---
+-CREATE FUNCTION pgp_sym_signatures(bytea, text, boolean)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_sym_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_sym_signatures(data, key, details, args)
+---
+-CREATE FUNCTION pgp_sym_signatures(bytea, text, boolean, text)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_sym_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_signatures(data, key)
+---
+-CREATE FUNCTION pgp_pub_signatures(bytea, bytea)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_signatures(data, key, psw)
+---
+-CREATE FUNCTION pgp_pub_signatures(bytea, bytea, text)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_signatures(data, key, psw, details)
+---
+-CREATE FUNCTION pgp_pub_signatures(bytea, bytea, text, boolean)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+-
+---
+--- pgp_pub_signatures(data, key, psw, details, args)
+---
+-CREATE FUNCTION pgp_pub_signatures(bytea, bytea, text, boolean, text)
+-RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
+-AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
+-LANGUAGE C IMMUTABLE STRICT;
+diff --git a/pgcrypto_openpgp--1.3.sql b/pgcrypto_openpgp--1.3.sql
+new file mode 100644
+index 0000000..a361792
+--- /dev/null
++++ b/pgcrypto_openpgp--1.3.sql
+@@ -0,0 +1,447 @@
++/* pgcrypto_openpgp/pgcrypto_openpgp--1.3.sql */
++
++-- complain if script is sourced in psql, rather than via CREATE EXTENSION
++\echo Use "CREATE EXTENSION pgcrypto_openpgp" to load this file. \quit
++
++CREATE FUNCTION digest(text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_digest'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION digest(bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_digest'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION hmac(text, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_hmac'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION hmac(bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_hmac'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION crypt(text, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pg_crypt'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION gen_salt(text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pg_gen_salt'
++LANGUAGE C VOLATILE STRICT;
++
++CREATE FUNCTION gen_salt(text, int4)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pg_gen_salt_rounds'
++LANGUAGE C VOLATILE STRICT;
++
++CREATE FUNCTION encrypt(bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_encrypt'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION decrypt(bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_decrypt'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION encrypt_iv(bytea, bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_encrypt_iv'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION decrypt_iv(bytea, bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_decrypt_iv'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION gen_random_bytes(int4)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_random_bytes'
++LANGUAGE C VOLATILE STRICT;
++
++--
++-- pgp_sym_encrypt(data, key)
++--
++CREATE FUNCTION pgp_sym_encrypt(text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_sym_encrypt_bytea(bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_sym_encrypt(data, key, args)
++--
++CREATE FUNCTION pgp_sym_encrypt(text, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_sym_encrypt_bytea(bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_sym_decrypt(data, key)
++--
++CREATE FUNCTION pgp_sym_decrypt(bytea, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_sym_decrypt_bytea(bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_sym_decrypt(data, key, args)
++--
++CREATE FUNCTION pgp_sym_decrypt(bytea, text, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_sym_decrypt_bytea(bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_encrypt(data, key)
++--
++CREATE FUNCTION pgp_pub_encrypt(text, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_pub_encrypt_bytea(bytea, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_pub_encrypt(data, key, args)
++--
++CREATE FUNCTION pgp_pub_encrypt(text, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_pub_encrypt_bytea(bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_pub_decrypt(data, key)
++--
++CREATE FUNCTION pgp_pub_decrypt(bytea, bytea)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_decrypt(data, key, psw)
++--
++CREATE FUNCTION pgp_pub_decrypt(bytea, bytea, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_decrypt(data, key, psw, arg)
++--
++CREATE FUNCTION pgp_pub_decrypt(bytea, bytea, text, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- PGP key ID
++--
++CREATE FUNCTION pgp_key_id(bytea)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_key_id_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp armor
++--
++CREATE FUNCTION armor(bytea)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pg_armor'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION dearmor(text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pg_dearmor'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgcrypto_armor_headers
++--
++
++CREATE FUNCTION armor(bytea, text[], text[])
++RETURNS text
++AS 'MODULE_PATHNAME', 'pg_armor'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_armor_headers(text, key OUT text, value OUT text)
++RETURNS SETOF record
++AS 'MODULE_PATHNAME', 'pgp_armor_headers'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_armor_header(text, text)
++RETURNS text
++AS $$
++SELECT string_agg(h.value, '') FROM pgp_armor_headers($1) h WHERE h.key = $2
++$$
++LANGUAGE sql IMMUTABLE STRICT;
++
++--
++-- pgcrypto_signatures
++--
++
++--
++-- pgp_sym_encrypt_sign(data, key, sigkey)
++--
++CREATE FUNCTION pgp_sym_encrypt_sign(text, text, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_sym_encrypt_sign_bytea(bytea, text, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_sym_encrypt_sign(data, key, sigkey, psw)
++--
++CREATE FUNCTION pgp_sym_encrypt_sign(text, text, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_sym_encrypt_sign_bytea(bytea, text, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_sym_encrypt_sign(data, key, sigkey, psw, args)
++--
++CREATE FUNCTION pgp_sym_encrypt_sign(text, text, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_sym_encrypt_sign_bytea(bytea, text, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_encrypt_sign_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_sym_decrypt_verify(data, key, sigkey)
++--
++CREATE FUNCTION pgp_sym_decrypt_verify(bytea, text, bytea)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_sym_decrypt_verify_bytea(bytea, text, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_sym_decrypt_verify(data, key, sigkey, psw)
++--
++CREATE FUNCTION pgp_sym_decrypt_verify(bytea, text, bytea, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_sym_decrypt_verify_bytea(bytea, text, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_sym_decrypt_verify(data, key, sigkey, psw, args)
++--
++CREATE FUNCTION pgp_sym_decrypt_verify(bytea, text, bytea, text, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_sym_decrypt_verify_bytea(bytea, text, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_sym_decrypt_verify_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_encrypt_sign(data, key, sigkey)
++--
++CREATE FUNCTION pgp_pub_encrypt_sign(text, bytea, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_pub_encrypt_sign_bytea(bytea, bytea, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_pub_encrypt_sign(data, key, sigkey, psw)
++--
++CREATE FUNCTION pgp_pub_encrypt_sign(text, bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_pub_encrypt_sign_bytea(bytea, bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_pub_encrypt_sign(data, key, sigkey, psw, args)
++--
++CREATE FUNCTION pgp_pub_encrypt_sign(text, bytea, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_text'
++LANGUAGE C STRICT;
++
++CREATE FUNCTION pgp_pub_encrypt_sign_bytea(bytea, bytea, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_encrypt_sign_bytea'
++LANGUAGE C STRICT;
++
++--
++-- pgp_pub_decrypt_verify(data, key, sigkey)
++--
++CREATE FUNCTION pgp_pub_decrypt_verify(bytea, bytea, bytea)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_pub_decrypt_verify_bytea(bytea, bytea, bytea)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_decrypt_verify(data, key, sigkey, psw)
++--
++CREATE FUNCTION pgp_pub_decrypt_verify(bytea, bytea, bytea, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_pub_decrypt_verify_bytea(bytea, bytea, bytea, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_decrypt_verify(data, key, sigkey, psw, arg)
++--
++CREATE FUNCTION pgp_pub_decrypt_verify(bytea, bytea, bytea, text, text)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_text'
++LANGUAGE C IMMUTABLE STRICT;
++
++CREATE FUNCTION pgp_pub_decrypt_verify_bytea(bytea, bytea, bytea, text, text)
++RETURNS bytea
++AS 'MODULE_PATHNAME', 'pgp_pub_decrypt_verify_bytea'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_main_key_id(key)
++--
++CREATE FUNCTION pgp_main_key_id(bytea)
++RETURNS text
++AS 'MODULE_PATHNAME', 'pgp_main_key_id_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_sym_signatures(data, key)
++--
++CREATE FUNCTION pgp_sym_signatures(bytea, text)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_sym_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_sym_signatures(data, key, details)
++--
++CREATE FUNCTION pgp_sym_signatures(bytea, text, boolean)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_sym_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_sym_signatures(data, key, details, args)
++--
++CREATE FUNCTION pgp_sym_signatures(bytea, text, boolean, text)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_sym_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_signatures(data, key)
++--
++CREATE FUNCTION pgp_pub_signatures(bytea, bytea)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_signatures(data, key, psw)
++--
++CREATE FUNCTION pgp_pub_signatures(bytea, bytea, text)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_signatures(data, key, psw, details)
++--
++CREATE FUNCTION pgp_pub_signatures(bytea, bytea, text, boolean)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
++
++--
++-- pgp_pub_signatures(data, key, psw, details, args)
++--
++CREATE FUNCTION pgp_pub_signatures(bytea, bytea, text, boolean, text)
++RETURNS TABLE (keyid text, digest text, pubkeyalgo text, creation_time timestamptz)
++AS 'MODULE_PATHNAME', 'pgp_pub_signatures_w'
++LANGUAGE C IMMUTABLE STRICT;
+diff --git a/pgcrypto_openpgp.control b/pgcrypto_openpgp.control
+index 48fe8ce..5f4a75a 100644
+--- a/pgcrypto_openpgp.control
++++ b/pgcrypto_openpgp.control
+@@ -1,5 +1,5 @@
+ # pgcrypto_openpgp extension
+ comment = 'cryptographic functions'
+-default_version = '1.2'
++default_version = '1.3'
+ module_pathname = '$libdir/pgcrypto_openpgp'
+ relocatable = true

--- a/debian/postgresql-pgcrypto-openpgp/rules
+++ b/debian/postgresql-pgcrypto-openpgp/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-VERSION=1.2-1
+VERSION=1.3-1
 PGMINORVERSION=$$(pg_config --version | sed 's/.* //')
 PGVERSION=$$(echo "$(PGMINORVERSION)" | cut -f1-2 -d.)
 PGMAJORVERSION=$$(echo "$(PGVERSION)" | cut -f1 -d.)


### PR DESCRIPTION
I had originally thought that it's OK not to care about the MDC if we
skip over the data, but that appears to not be exactly true.  There's
some corner case where ignoring the MDC in a "stream" context would
cause the compressed data packet to be only partially read, resulting in
weird errors about packet headers.  Fix by fully handling MDC, just like
pgp-encrypt.c does.

Additionally, update to the version of the armor header patch which got
pushed upstream in commit 32984d8fc3dbb90a3fafb69fece0134f1ea790f9.  The
C-function interface changed slightly, but we can provide a trivial SQL
function to provide the same functionality.

Bump the version of the deb package to 1.3-1 and the PostgreSQL
extension to 1.3 due to the interface change in the armor header
functionality.  ALTER EXTENSION pgcrypto_openpgp UPDATE TO '1.3'; will
be necessary after upgrading the package.  Unfortunately it's possible
to see the error 'could not find function "pgp_armor_header_w"' between
installing the .deb and running the ALTER EXTENSION.  Caveat emptor.
